### PR TITLE
Load fleet data from JSON for fleet page

### DIFF
--- a/app/data/fleet.json
+++ b/app/data/fleet.json
@@ -1,0 +1,266 @@
+[
+  {
+    "sailor": "NH",
+    "boat": "Braken Two",
+    "sail_number": 45,
+    "initial_handicap": 520
+  },
+  {
+    "sailor": "IW",
+    "boat": "Thistle",
+    "sail_number": 49,
+    "initial_handicap": 300
+  },
+  {
+    "sailor": null,
+    "boat": "Calypso",
+    "sail_number": 52,
+    "initial_handicap": 360
+  },
+  {
+    "sailor": "NP",
+    "boat": "Drake",
+    "sail_number": 86,
+    "initial_handicap": 200
+  },
+  {
+    "sailor": null,
+    "boat": "Pelican",
+    "sail_number": 102,
+    "initial_handicap": -118
+  },
+  {
+    "sailor": "MB",
+    "boat": "Iris",
+    "sail_number": 136,
+    "initial_handicap": 290
+  },
+  {
+    "sailor": null,
+    "boat": "Beatrice",
+    "sail_number": 156,
+    "initial_handicap": 150
+  },
+  {
+    "sailor": "SFB",
+    "boat": "Percy",
+    "sail_number": 264,
+    "initial_handicap": 110
+  },
+  {
+    "sailor": "BP",
+    "boat": "Ysella",
+    "sail_number": 298,
+    "initial_handicap": -298
+  },
+  {
+    "sailor": "SF",
+    "boat": "Guilan Dhiu",
+    "sail_number": 334,
+    "initial_handicap": 280
+  },
+  {
+    "sailor": "C",
+    "boat": "Salome",
+    "sail_number": 346,
+    "initial_handicap": -86
+  },
+  {
+    "sailor": null,
+    "boat": "Marie Louise",
+    "sail_number": 348,
+    "initial_handicap": 150
+  },
+  {
+    "sailor": "PD",
+    "boat": "Abeleki",
+    "sail_number": 383,
+    "initial_handicap": 430
+  },
+  {
+    "sailor": "JW",
+    "boat": "Jakana",
+    "sail_number": 400,
+    "initial_handicap": 183
+  },
+  {
+    "sailor": "ME",
+    "boat": "Alice Rose",
+    "sail_number": 417,
+    "initial_handicap": 374
+  },
+  {
+    "sailor": "AB",
+    "boat": "Lucy",
+    "sail_number": 432,
+    "initial_handicap": 170
+  },
+  {
+    "sailor": "SP",
+    "boat": "Grace of St Just",
+    "sail_number": 433,
+    "initial_handicap": 170
+  },
+  {
+    "sailor": "CF",
+    "boat": "Sophie",
+    "sail_number": 455,
+    "initial_handicap": -92
+  },
+  {
+    "sailor": "RC",
+    "boat": "Annie",
+    "sail_number": 503,
+    "initial_handicap": 165
+  },
+  {
+    "sailor": "MP",
+    "boat": "Sterren Vor",
+    "sail_number": 518,
+    "initial_handicap": -226
+  },
+  {
+    "sailor": null,
+    "boat": "Black Shrimp",
+    "sail_number": 598,
+    "initial_handicap": 360
+  },
+  {
+    "sailor": "SA",
+    "boat": "Bluebell",
+    "sail_number": 623,
+    "initial_handicap": 200
+  },
+  {
+    "sailor": "SS",
+    "boat": "Jackdaw",
+    "sail_number": 626,
+    "initial_handicap": -400
+  },
+  {
+    "sailor": "AP",
+    "boat": "Agnes",
+    "sail_number": 650,
+    "initial_handicap": 340
+  },
+  {
+    "sailor": "JP",
+    "boat": "Little Tern",
+    "sail_number": 678,
+    "initial_handicap": -68
+  },
+  {
+    "sailor": "CH",
+    "boat": "Carla Louise",
+    "sail_number": 727,
+    "initial_handicap": 98
+  },
+  {
+    "sailor": "DS",
+    "boat": "Winnie",
+    "sail_number": 736,
+    "initial_handicap": 150
+  },
+  {
+    "sailor": "PF",
+    "boat": "Kiff",
+    "sail_number": 770,
+    "initial_handicap": 150
+  },
+  {
+    "sailor": "MJ",
+    "boat": "Humbug",
+    "sail_number": 802,
+    "initial_handicap": 200
+  },
+  {
+    "sailor": "AN",
+    "boat": "Moondance",
+    "sail_number": 816,
+    "initial_handicap": 197
+  },
+  {
+    "sailor": "AM",
+    "boat": "Reward",
+    "sail_number": 842,
+    "initial_handicap": 246
+  },
+  {
+    "sailor": "SP",
+    "boat": "Dawn of Polruan",
+    "sail_number": 889,
+    "initial_handicap": 279
+  },
+  {
+    "sailor": "GD",
+    "boat": "Lady Elana",
+    "sail_number": 921,
+    "initial_handicap": 410
+  },
+  {
+    "sailor": "PO",
+    "boat": "Lady Lalla",
+    "sail_number": 924,
+    "initial_handicap": 156
+  },
+  {
+    "sailor": "BC",
+    "boat": "Disee",
+    "sail_number": 1056,
+    "initial_handicap": 300
+  },
+  {
+    "sailor": "RS",
+    "boat": "Sparrow",
+    "sail_number": 1078,
+    "initial_handicap": 180
+  },
+  {
+    "sailor": "SA",
+    "boat": "Daydream",
+    "sail_number": 1131,
+    "initial_handicap": 150
+  },
+  {
+    "sailor": "RJ",
+    "boat": "Green Dragon",
+    "sail_number": 1134,
+    "initial_handicap": 200
+  },
+  {
+    "sailor": "TW",
+    "boat": "Firefly",
+    "sail_number": 1154,
+    "initial_handicap": -350
+  },
+  {
+    "sailor": "MG",
+    "boat": "",
+    "sail_number": 1200,
+    "initial_handicap": 300
+  },
+  {
+    "sailor": "AG",
+    "boat": "Blackbird",
+    "sail_number": 534,
+    "initial_handicap": 110
+  },
+  {
+    "sailor": "Pa",
+    "boat": "Nir Na Nog",
+    "sail_number": 687,
+    "initial_handicap": 280
+  },
+  {
+    "sailor": "LM",
+    "boat": "Julia Neal",
+    "sail_number": 392,
+    "initial_handicap": -120
+  },
+  {
+    "sailor": "HF",
+    "boat": "Stella Maris",
+    "sail_number": 1120,
+    "initial_handicap": 360
+  }
+]

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,4 +1,6 @@
 from flask import Blueprint, redirect, render_template, url_for
+import json
+from pathlib import Path
 
 
 bp = Blueprint('main', __name__)
@@ -53,7 +55,10 @@ def standings_league():
 @bp.route('/fleet')
 def fleet():
     breadcrumbs = [('Fleet', None)]
-    return render_template('fleet.html', title='Fleet', breadcrumbs=breadcrumbs)
+    data_path = Path(__file__).resolve().parent / 'data' / 'fleet.json'
+    with data_path.open() as f:
+        fleet = json.load(f)
+    return render_template('fleet.html', title='Fleet', breadcrumbs=breadcrumbs, fleet=fleet)
 
 
 @bp.route('/rules')

--- a/app/templates/fleet.html
+++ b/app/templates/fleet.html
@@ -7,10 +7,21 @@
 </div>
 <table class="table table-striped">
   <thead>
-    <tr><th>Sailor</th><th>Boat</th><th>Sail No.</th><th>Starting Hcp</th><th>Current Hcp</th></tr>
+    <tr><th>Sailor</th><th>Boat</th><th>Sail No.</th><th>Starting Hcp</th></tr>
   </thead>
   <tbody>
-    <tr><td colspan="5" class="text-muted">No competitors.</td></tr>
+    {% if fleet %}
+      {% for competitor in fleet %}
+        <tr>
+          <td>{{ competitor.sailor or '?' }}</td>
+          <td>{{ competitor.boat }}</td>
+          <td>{{ competitor.sail_number }}</td>
+          <td>{{ competitor.initial_handicap }}</td>
+        </tr>
+      {% endfor %}
+    {% else %}
+      <tr><td colspan="4" class="text-muted">No competitors.</td></tr>
+    {% endif %}
   </tbody>
 </table>
 {% endblock %}


### PR DESCRIPTION
## Summary
- store initial fleet data in `app/data/fleet.json`
- load fleet data from JSON and pass to fleet template
- render fleet table dynamically in `fleet.html`
- drop unused `current handicap` column from fleet table and data

## Testing
- `pytest -q`
- `python -m json.tool app/data/fleet.json > /dev/null`


------
https://chatgpt.com/codex/tasks/task_e_6898f97624048320b381f0de961e6c6e