### PR TITLE
Refactor data layout into seasonal series directories

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -8,24 +8,54 @@ bp = Blueprint('main', __name__)
 DATA_DIR = Path(__file__).resolve().parent.parent / 'data'
 
 
+def _series_meta_paths():
+    """Yield paths to all series metadata files across seasons."""
+    for season_dir in DATA_DIR.iterdir():
+        series_root = season_dir / "series"
+        if series_root.is_dir():
+            yield from series_root.glob("*/series_metadata.json")
+
+
+def _load_series_entries():
+    """Return list of series with their race data."""
+    entries = []
+    for meta_path in sorted(_series_meta_paths()):
+        with meta_path.open() as f:
+            series = json.load(f)
+        races = []
+        races_dir = meta_path.parent / "races"
+        for race_id in series.get("race_ids", []):
+            race_path = races_dir / f"{race_id}.json"
+            if race_path.exists():
+                with race_path.open() as rf:
+                    races.append(json.load(rf))
+        entries.append({"series": series, "races": races})
+    return entries
+
+
+def _find_series(series_id: str):
+    """Return (series, races) for the given series id or (None, None)."""
+    for entry in _load_series_entries():
+        if entry["series"].get("series_id") == series_id:
+            return entry["series"], entry["races"]
+    return None, None
+
+
+def _find_race(race_id: str):
+    """Return race data for the given race id or None if not found."""
+    for meta_path in _series_meta_paths():
+        races_dir = meta_path.parent / "races"
+        race_path = races_dir / f"{race_id}.json"
+        if race_path.exists():
+            with race_path.open() as f:
+                return json.load(f)
+    return None
+
+
 @bp.app_context_processor
 def inject_nav_data():
     """Load series and race data for navigation menus."""
-    series_entries = []
-    series_dir = DATA_DIR / 'series'
-    races_dir = DATA_DIR / 'races'
-    if series_dir.exists():
-        for path in sorted(series_dir.glob('*.json')):
-            with path.open() as f:
-                series = json.load(f)
-            races = []
-            for race_id in series.get('race_ids', []):
-                race_path = races_dir / f"{race_id}.json"
-                if race_path.exists():
-                    with race_path.open() as rf:
-                        races.append(json.load(rf))
-            series_entries.append({'series': series, 'races': races})
-    return {'nav_series': series_entries}
+    return {'nav_series': _load_series_entries()}
 
 
 @bp.route('/')
@@ -36,32 +66,22 @@ def index():
 @bp.route('/race-sheets')
 def series_index():
     series_list = []
-    series_dir = DATA_DIR / 'series'
-    races_dir = DATA_DIR / 'races'
-    if series_dir.exists():
-        for path in sorted(series_dir.glob('*.json')):
-            with path.open() as f:
-                series = json.load(f)
-            race_dates = []
-            for race_id in series.get('race_ids', []):
-                race_path = races_dir / f"{race_id}.json"
-                if race_path.exists():
-                    with race_path.open() as rf:
-                        race = json.load(rf)
-                    if race.get('date'):
-                        race_dates.append(race['date'])
-            if race_dates:
-                dates = f"{min(race_dates)} - {max(race_dates)}" if len(set(race_dates)) > 1 else race_dates[0]
-            else:
-                dates = ''
-            series_list.append({
-                'series_id': series.get('series_id'),
-                'name': series.get('name'),
-                'dates': dates,
-                'num_races': len(series.get('race_ids', [])),
-                'updated_at': series.get('updated_at') or series.get('created_at', ''),
-            })
-    return render_template('race_sheets.html', title='Series Index', series_list=series_list)
+    for entry in _load_series_entries():
+        series = entry["series"]
+        races = entry["races"]
+        race_dates = [r.get("date") for r in races if r.get("date")]
+        if race_dates:
+            dates = f"{min(race_dates)} - {max(race_dates)}" if len(set(race_dates)) > 1 else race_dates[0]
+        else:
+            dates = ""
+        series_list.append({
+            "series_id": series.get("series_id"),
+            "name": series.get("name"),
+            "dates": dates,
+            "num_races": len(races),
+            "updated_at": series.get("updated_at") or series.get("created_at", ""),
+        })
+    return render_template("race_sheets.html", title="Series Index", series_list=series_list)
 
 
 @bp.route('/series/new')
@@ -73,12 +93,7 @@ def series_new():
 @bp.route('/races/new')
 def race_new():
     breadcrumbs = [('Race Sheets', url_for('main.series_index')), ('Create New Race', None)]
-    series_dir = DATA_DIR / 'series'
-    series_list = []
-    if series_dir.exists():
-        for path in sorted(series_dir.glob('*.json')):
-            with path.open() as f:
-                series_list.append(json.load(f))
+    series_list = [entry['series'] for entry in _load_series_entries()]
     fleet_path = DATA_DIR / 'fleet.json'
     with fleet_path.open() as f:
         fleet_data = json.load(f)
@@ -88,29 +103,18 @@ def race_new():
 
 @bp.route('/series/<series_id>')
 def series_detail(series_id):
-    series_path = DATA_DIR / 'series' / f"{series_id}.json"
-    if not series_path.exists():
+    series, races = _find_series(series_id)
+    if series is None:
         abort(404)
-    with series_path.open() as f:
-        series = json.load(f)
-    races = []
-    races_dir = DATA_DIR / 'races'
-    for race_id in series.get('race_ids', []):
-        race_path = races_dir / f"{race_id}.json"
-        if race_path.exists():
-            with race_path.open() as rf:
-                races.append(json.load(rf))
     breadcrumbs = [('Race Sheets', url_for('main.series_index')), (series.get('name', series_id), None)]
     return render_template('series_detail.html', title=series.get('name', series_id), breadcrumbs=breadcrumbs, series=series, races=races)
 
 
 @bp.route('/races/<race_id>')
 def race_sheet(race_id):
-    race_path = DATA_DIR / 'races' / f"{race_id}.json"
-    if not race_path.exists():
+    race = _find_race(race_id)
+    if race is None:
         abort(404)
-    with race_path.open() as f:
-        race = json.load(f)
     breadcrumbs = [('Race Sheets', url_for('main.series_index')), (race.get('name', race_id), None)]
     return render_template('race_sheet.html', title=race.get('name', race_id), breadcrumbs=breadcrumbs, race=race)
 

--- a/data/2025/series/CastF/races/RACE_2025-06-06_CastF4.json
+++ b/data/2025/series/CastF/races/RACE_2025-06-06_CastF4.json
@@ -1,5 +1,5 @@
 {
-  "race_id": "RACE_2025_06Jun_CastF4",
+  "race_id": "RACE_2025-06-06_CastF4",
   "series_id": "SER_2025_CASTF",
   "name": "CastF4",
   "date": "2025-06-06",

--- a/data/2025/series/CastF/series_metadata.json
+++ b/data/2025/series/CastF/series_metadata.json
@@ -5,7 +5,8 @@
   "created_at": "2025-04-01T09:00:00Z",
   "status": "open",
   "race_ids": [
-    "RACE_2025_06Jun_CastF4"
+    "RACE_2025-06-06_CastF4"
   ],
-  "notes": ""
+  "notes": "",
+  "slug": "CastF"
 }

--- a/data/2025/series/MYHF/races/RACE_2025-08-08_MYHF5.json
+++ b/data/2025/series/MYHF/races/RACE_2025-08-08_MYHF5.json
@@ -1,5 +1,5 @@
 {
-  "race_id": "RACE_2025_08Aug_MYHF5",
+  "race_id": "RACE_2025-08-08_MYHF5",
   "series_id": "SER_2025_MYHF",
   "name": "MYHF5",
   "date": "2025-08-08",
@@ -24,7 +24,9 @@
     {
       "competitor_id": "C_45",
       "initial_handicap_s_per_hr": 520,
-      "finish": { "status": "DNF" }
+      "finish": {
+        "status": "DNF"
+      }
     }
   ],
   "results": {

--- a/data/2025/series/MYHF/series_metadata.json
+++ b/data/2025/series/MYHF/series_metadata.json
@@ -5,7 +5,8 @@
   "created_at": "2025-04-01T09:00:00Z",
   "status": "open",
   "race_ids": [
-    "RACE_2025_08Aug_MYHF5"
+    "RACE_2025-08-08_MYHF5"
   ],
-  "notes": ""
+  "notes": "",
+  "slug": "MYHF"
 }


### PR DESCRIPTION
## Summary
- move series and race JSON into `data/<season>/series/<slug>` directories
- add slug metadata and update race ids to date-based convention
- update routes to locate series/races from new season structure

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899bffebf208320bec3c4b7706ee37a