### PR TITLE
Refactor race data layout to year/series hierarchy

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -11,9 +11,8 @@ DATA_DIR = Path(__file__).resolve().parent.parent / 'data'
 def _series_meta_paths():
     """Yield paths to all series metadata files across seasons."""
     for season_dir in DATA_DIR.iterdir():
-        series_root = season_dir / "series"
-        if series_root.is_dir():
-            yield from series_root.glob("*/series_metadata.json")
+        if season_dir.is_dir():
+            yield from season_dir.glob("*/series_metadata.json")
 
 
 def _load_series_entries():

--- a/data/2025/CastF/races/RACE_2025-06-06_CastF_4.json
+++ b/data/2025/CastF/races/RACE_2025-06-06_CastF_4.json
@@ -1,5 +1,5 @@
 {
-  "race_id": "RACE_2025-06-06_CastF4",
+  "race_id": "RACE_2025-06-06_CastF_4",
   "series_id": "SER_2025_CASTF",
   "name": "CastF4",
   "date": "2025-06-06",

--- a/data/2025/CastF/series_metadata.json
+++ b/data/2025/CastF/series_metadata.json
@@ -5,7 +5,7 @@
   "created_at": "2025-04-01T09:00:00Z",
   "status": "open",
   "race_ids": [
-    "RACE_2025-06-06_CastF4"
+    "RACE_2025-06-06_CastF_4"
   ],
   "notes": "",
   "slug": "CastF"

--- a/data/2025/MYHF/races/RACE_2025-08-08_MYHF_5.json
+++ b/data/2025/MYHF/races/RACE_2025-08-08_MYHF_5.json
@@ -1,5 +1,5 @@
 {
-  "race_id": "RACE_2025-08-08_MYHF5",
+  "race_id": "RACE_2025-08-08_MYHF_5",
   "series_id": "SER_2025_MYHF",
   "name": "MYHF5",
   "date": "2025-08-08",

--- a/data/2025/MYHF/series_metadata.json
+++ b/data/2025/MYHF/series_metadata.json
@@ -5,7 +5,7 @@
   "created_at": "2025-04-01T09:00:00Z",
   "status": "open",
   "race_ids": [
-    "RACE_2025-08-08_MYHF5"
+    "RACE_2025-08-08_MYHF_5"
   ],
   "notes": "",
   "slug": "MYHF"


### PR DESCRIPTION
## Summary
- reorganize race data into `data/<year>/<series>` directories
- update race IDs and metadata to match new layout
- adjust series discovery logic to traverse new structure

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a1e235b188320ad08391f367b089e