### PR TITLE
Simplify series metadata structure

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -24,11 +24,9 @@ def _load_series_entries():
             series = json.load(f)
         races = []
         races_dir = meta_path.parent / "races"
-        for race_id in series.get("race_ids", []):
-            race_path = races_dir / f"{race_id}.json"
-            if race_path.exists():
-                with race_path.open() as rf:
-                    races.append(json.load(rf))
+        for race_path in sorted(races_dir.glob("*.json")):
+            with race_path.open() as rf:
+                races.append(json.load(rf))
         entries.append({"series": series, "races": races})
     return entries
 
@@ -42,11 +40,9 @@ def _load_nav_data():
             series = json.load(f)
         races = []
         races_dir = meta_path.parent / "races"
-        for race_id in series.get("race_ids", []):
-            race_path = races_dir / f"{race_id}.json"
-            if race_path.exists():
-                with race_path.open() as rf:
-                    races.append(json.load(rf))
+        for race_path in sorted(races_dir.glob("*.json")):
+            with race_path.open() as rf:
+                races.append(json.load(rf))
         seasons.setdefault(season, []).append({"series": series, "races": races})
 
     nav = []
@@ -104,7 +100,6 @@ def series_index():
             "name": series.get("name"),
             "dates": dates,
             "num_races": len(races),
-            "updated_at": series.get("updated_at") or series.get("created_at", ""),
         })
     return render_template("race_series.html", title="Series Index", series_list=series_list)
 
@@ -135,12 +130,6 @@ def race_or_series_new():
             series_id = series_meta.get('series_id')
             season_dir = meta_path.parent.parent
             series_dir = meta_path.parent
-            race_ids = series_meta.setdefault('race_ids', [])
-            if race_id not in race_ids:
-                race_ids.append(race_id)
-            series_meta['updated_at'] = timestamp
-            with meta_path.open('w') as f:
-                json.dump(series_meta, f, indent=2)
         else:
             series_id = request.form.get('new_series_id')
             series_name = request.form.get('new_series_name')
@@ -152,11 +141,6 @@ def race_or_series_new():
                 'series_id': series_id,
                 'name': series_name,
                 'season': int(season),
-                'created_at': timestamp,
-                'status': 'open',
-                'race_ids': [race_id],
-                'notes': '',
-                'slug': series_name,
             }
             with (series_dir / 'series_metadata.json').open('w') as f:
                 json.dump(series_meta, f, indent=2)

--- a/app/templates/race_series.html
+++ b/app/templates/race_series.html
@@ -6,22 +6,21 @@
   <a class="btn btn-primary" href="{{ url_for('main.race_or_series_new') }}">Create New Race or Series</a>
 </div>
 <table class="table table-striped">
-  <thead>
-    <tr><th>Series</th><th>Dates</th><th># Races</th><th>Last updated</th><th>Actions</th></tr>
-  </thead>
+    <thead>
+      <tr><th>Series</th><th>Dates</th><th># Races</th><th>Actions</th></tr>
+    </thead>
   <tbody>
     {% if series_list %}
       {% for s in series_list %}
         <tr>
           <td><a href="{{ url_for('main.series_detail', series_id=s.series_id) }}">{{ s.name }}</a></td>
           <td>{{ s.dates or '-' }}</td>
-          <td>{{ s.num_races }}</td>
-          <td>{{ s.updated_at or '-' }}</td>
-          <td><a class="btn btn-sm btn-secondary" href="{{ url_for('main.series_detail', series_id=s.series_id) }}">View</a></td>
+            <td>{{ s.num_races }}</td>
+            <td><a class="btn btn-sm btn-secondary" href="{{ url_for('main.series_detail', series_id=s.series_id) }}">View</a></td>
         </tr>
       {% endfor %}
     {% else %}
-      <tr><td colspan="5" class="text-muted">No series yet.</td></tr>
+        <tr><td colspan="4" class="text-muted">No series yet.</td></tr>
     {% endif %}
   </tbody>
 </table>

--- a/data/2025/CastF/series_metadata.json
+++ b/data/2025/CastF/series_metadata.json
@@ -1,10 +1,5 @@
 {
   "series_id": "SER_2025_CASTF",
   "name": "CastF",
-  "season": 2025,
-  "created_at": "2025-01-01T00:00:00Z",
-  "status": "open",
-  "race_ids": [],
-  "notes": "",
-  "slug": "CastF"
+  "season": 2025
 }

--- a/data/2025/CastS/series_metadata.json
+++ b/data/2025/CastS/series_metadata.json
@@ -1,10 +1,5 @@
 {
   "series_id": "SER_2025_CASTS",
   "name": "CastS",
-  "season": 2025,
-  "created_at": "2025-01-01T00:00:00Z",
-  "status": "open",
-  "race_ids": [],
-  "notes": "",
-  "slug": "CastS"
+  "season": 2025
 }

--- a/data/2025/Cups/series_metadata.json
+++ b/data/2025/Cups/series_metadata.json
@@ -1,10 +1,5 @@
 {
   "series_id": "SER_2025_CUPS",
   "name": "Cups",
-  "season": 2025,
-  "created_at": "2025-01-01T00:00:00Z",
-  "status": "open",
-  "race_ids": [],
-  "notes": "",
-  "slug": "Cups"
+  "season": 2025
 }

--- a/data/2025/MC&R/series_metadata.json
+++ b/data/2025/MC&R/series_metadata.json
@@ -1,10 +1,5 @@
 {
   "series_id": "SER_2025_MC&R",
   "name": "MC&R",
-  "season": 2025,
-  "created_at": "2025-01-01T00:00:00Z",
-  "status": "open",
-  "race_ids": [],
-  "notes": "",
-  "slug": "MC&R"
+  "season": 2025
 }

--- a/data/2025/MC&RS/series_metadata.json
+++ b/data/2025/MC&RS/series_metadata.json
@@ -1,10 +1,5 @@
 {
   "series_id": "SER_2025_MC&RS",
   "name": "MC&RS",
-  "season": 2025,
-  "created_at": "2025-01-01T00:00:00Z",
-  "status": "open",
-  "race_ids": [],
-  "notes": "",
-  "slug": "MC&RS"
+  "season": 2025
 }

--- a/data/2025/MYHF/series_metadata.json
+++ b/data/2025/MYHF/series_metadata.json
@@ -1,10 +1,5 @@
 {
   "series_id": "SER_2025_MYHF",
   "name": "MYHF",
-  "season": 2025,
-  "created_at": "2025-01-01T00:00:00Z",
-  "status": "open",
-  "race_ids": [],
-  "notes": "",
-  "slug": "MYHF"
+  "season": 2025
 }

--- a/data/2025/PenD/series_metadata.json
+++ b/data/2025/PenD/series_metadata.json
@@ -1,10 +1,5 @@
 {
   "series_id": "SER_2025_PEND",
   "name": "PenD",
-  "season": 2025,
-  "created_at": "2025-01-01T00:00:00Z",
-  "status": "open",
-  "race_ids": [],
-  "notes": "",
-  "slug": "PenD"
+  "season": 2025
 }


### PR DESCRIPTION
## Summary
- strip series metadata JSON files to only series_id, name, season
- remove race_id tracking and extra fields when creating or reading series metadata
- streamline series index template for leaner schema

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a497172a48320bcf401cc9ce60848