### PR TITLE
Enable race selection on series pages

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -21,7 +21,7 @@
                 {% for season in nav_race_series %}
                   <li><h6 class="dropdown-header">{{ season.season }}</h6></li>
                   {% for entry in season.series %}
-                    <li><h6 class="dropdown-header ms-3">{{ entry.series.name }}</h6></li>
+                    <li><a class="dropdown-item ms-3" href="{{ url_for('main.series_detail', series_id=entry.series.series_id) }}">{{ entry.series.name }}</a></li>
                     {% for race in entry.races %}
                       <li><a class="dropdown-item ms-5" href="{{ url_for('main.race_sheet', race_id=race.race_id) }}">{{ race.date }}</a></li>
                     {% endfor %}

--- a/app/templates/series_detail.html
+++ b/app/templates/series_detail.html
@@ -2,29 +2,70 @@
 
 {% block content %}
 <h1>{{ series.name }}</h1>
-<div class="mb-3">
-  <a class="btn btn-primary" href="{{ url_for('main.race_or_series_new') }}">Create New Race or Series</a>
+<form method="get" class="mb-3">
+  <select name="race_id" class="form-select" onchange="this.form.submit()">
+    <option value="">Select a race</option>
+    {% for race in races %}
+      <option value="{{ race.race_id }}" {% if selected_race and selected_race.race_id == race.race_id %}selected{% endif %}>
+        {{ race.name }} ({{ race.date }})
+      </option>
+    {% endfor %}
+    <option value="__new__">Create New Race</option>
+  </select>
+</form>
+
+{% if selected_race %}
+<div class="card mb-3">
+  <div class="card-body">
+    <div class="mb-3">
+      <label for="start_time" class="form-label">Start Time</label>
+      <input type="text" id="start_time" class="form-control" value="{{ selected_race.start_time }}">
+    </div>
+    <div class="mb-3">
+      <label class="form-label">Number of Finishers</label>
+      <input type="text" class="form-control" value="{{ finisher_count }}" readonly>
+    </div>
+  </div>
 </div>
-<table class="table table-striped">
-  <thead>
-    <tr><th>Date</th><th>Race</th><th>Start Time</th><th># Entrants</th><th># Finishers</th><th>Status</th><th>Last updated</th></tr>
-  </thead>
-  <tbody>
-    {% if races %}
-      {% for race in races %}
-        <tr>
-          <td>{{ race.date }}</td>
-          <td><a href="{{ url_for('main.race_sheet', race_id=race.race_id) }}">{{ race.name }}</a></td>
-          <td>{{ race.start_time }}</td>
-          <td>{{ race.entrants|length }}</td>
-          <td>{{ race.results|length }}</td>
-          <td>{{ race.status }}</td>
-          <td>{{ race.updated_at or race.created_at }}</td>
-        </tr>
-      {% endfor %}
-    {% else %}
-      <tr><td colspan="7" class="text-muted">No races yet.</td></tr>
-    {% endif %}
-  </tbody>
-</table>
+
+<div class="table-responsive">
+  <table class="table table-bordered table-sm align-middle">
+    <thead class="table-light">
+      <tr>
+        <th>Sailor</th><th>Boat</th><th>Sail No.</th>
+        <th>Initial Hcp</th><th>Finish</th><th>On Course (s)</th>
+        <th>Abs Pos</th><th>Allowance</th><th>Adj Time (s)</th>
+        <th>Adj Time</th><th>Hcp Pos</th><th>Race Pts</th>
+        <th>League Pts</th><th>Full Δ</th><th>Scaled Δ</th>
+        <th>Actual Δ</th><th>Revised Hcp</th><th>Place</th>
+      </tr>
+    </thead>
+    <tbody>
+    {% for comp in fleet %}
+      {% set result = (selected_race.results or {}).get(comp.competitor_id, {}) %}
+      <tr>
+        <td>{{ comp.sailor_name }}</td>
+        <td>{{ comp.boat_name }}</td>
+        <td>{{ comp.sail_no }}</td>
+        <td>{{ comp.current_handicap_s_per_hr }}</td>
+        <td><input type="text" class="form-control form-control-sm" value="{{ result.finish_time or '' }}"></td>
+        <td>{{ result.on_course_secs or '' }}</td>
+        <td>{{ result.abs_pos or '' }}</td>
+        <td>{{ result.allowance or '' }}</td>
+        <td>{{ result.adj_time_secs or '' }}</td>
+        <td>{{ result.adj_time or '' }}</td>
+        <td>{{ result.hcp_pos or '' }}</td>
+        <td>{{ result.race_pts or '' }}</td>
+        <td>{{ result.league_pts or '' }}</td>
+        <td>{{ result.full_delta or '' }}</td>
+        <td>{{ result.scaled_delta or '' }}</td>
+        <td>{{ result.actual_delta or '' }}</td>
+        <td>{{ result.revised_hcp or '' }}</td>
+        <td>{{ result.place or '' }}</td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% endif %}
 {% endblock %}

--- a/tests/test_series_detail.py
+++ b/tests/test_series_detail.py
@@ -1,0 +1,55 @@
+import json
+import os
+import sys
+from pathlib import Path
+
+from flask import Flask
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from app import routes
+
+
+def test_finish_time_loaded(monkeypatch, tmp_path):
+    # Prepare temporary fleet data
+    fleet_data = {
+        "competitors": [
+            {
+                "competitor_id": "C_45",
+                "sailor_name": "NH",
+                "boat_name": "Braken Two",
+                "sail_no": "45",
+                "current_handicap_s_per_hr": 520,
+            }
+        ]
+    }
+    (tmp_path / "fleet.json").write_text(json.dumps(fleet_data))
+
+    # Patch DATA_DIR to temporary path containing fleet
+    monkeypatch.setattr(routes, "DATA_DIR", tmp_path)
+
+    # Fake series and race data
+    def fake_find_series(series_id):
+        return {"series_id": series_id, "name": "Test Series"}, [
+            {"race_id": "R1", "name": "Race 1", "date": "2025-01-01"}
+        ]
+
+    def fake_find_race(race_id):
+        return {
+            "race_id": race_id,
+            "results": [
+                {"competitor_id": "C_45", "finish_time": "12:34"}
+            ],
+        }
+
+    monkeypatch.setattr(routes, "_find_series", fake_find_series)
+    monkeypatch.setattr(routes, "_find_race", fake_find_race)
+
+    templates = Path(__file__).resolve().parent.parent / "app" / "templates"
+    app = Flask(__name__, template_folder=str(templates))
+    app.register_blueprint(routes.bp)
+
+    with app.test_client() as client:
+        resp = client.get("/series/TEST?race_id=R1")
+        assert resp.status_code == 200
+        html = resp.get_data(as_text=True)
+        assert 'value="12:34"' in html


### PR DESCRIPTION
## Summary
- Convert race results to a competitor-indexed mapping so finish times load correctly
- Add regression test ensuring finish times display in race details

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a4cd3500c8320bcca86de02b6c541