### PR TITLE
Populate race page from JSON and unify access

### DIFF
--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,0 +1,28 @@
+import pytest
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from app import create_app
+
+
+@pytest.fixture()
+def client():
+    app = create_app()
+    app.config.update({'TESTING': True})
+    with app.test_client() as client:
+        yield client
+
+
+def test_race_page_uses_race_json_data(client):
+    res = client.get('/series/SER_2025_MYHF?race_id=RACE_2025-07-11_MYHF_1')
+    html = res.get_data(as_text=True)
+    assert 'value="18:25:00"' in html
+    assert 'value="19:52:41"' in html
+    assert 'value="8"' in html
+
+
+def test_race_sheet_redirects(client):
+    res = client.get('/races/RACE_2025-07-11_MYHF_1', follow_redirects=False)
+    assert res.status_code == 302
+    assert '/series/SER_2025_MYHF?race_id=RACE_2025-07-11_MYHF_1' in res.headers['Location']


### PR DESCRIPTION
## Summary
- Load start and finish times from race JSON entrants and count finishers
- Redirect direct race URLs to the series page so all links show the same race view
- Test race page data population and redirect behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a08c36f5108320840784e260c5424b