### PR TITLE
Make Race Series dropdown scrollable

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -5,6 +5,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{{ title }} - Shrimper</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384" crossorigin="anonymous">
+    <style>
+      .scrollable-dropdown {
+        max-height: 70vh;
+        overflow-y: auto;
+      }
+    </style>
   </head>
   <body>
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
@@ -17,7 +23,7 @@
           <ul class="navbar-nav me-auto mb-2 mb-lg-0">
             <li class="nav-item dropdown">
               <a class="nav-link dropdown-toggle" href="#" id="raceSeriesDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">Race Series</a>
-              <ul class="dropdown-menu" aria-labelledby="raceSeriesDropdown">
+              <ul class="dropdown-menu scrollable-dropdown" aria-labelledby="raceSeriesDropdown">
                 {% for season in nav_race_series %}
                   <li><h6 class="dropdown-header">{{ season.season }}</h6></li>
                   {% for entry in season.series %}


### PR DESCRIPTION
## Summary
- limit Race Series dropdown height and enable vertical scrolling to access long menus

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0b388df6c8320bc4eef1c0a20bdfa