### PR TITLE
Add races index page

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -15,29 +15,13 @@
   <body>
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
       <div class="container-fluid">
-        <a class="navbar-brand" href="{{ url_for('main.series_index') }}">Shrimper</a>
+        <a class="navbar-brand" href="{{ url_for('main.races') }}">Shrimper</a>
         <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
           <span class="navbar-toggler-icon"></span>
         </button>
         <div class="collapse navbar-collapse" id="navbarNav">
           <ul class="navbar-nav me-auto mb-2 mb-lg-0">
-            <li class="nav-item dropdown">
-              <a class="nav-link dropdown-toggle" href="#" id="raceSeriesDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">Race Series</a>
-              <ul class="dropdown-menu scrollable-dropdown" aria-labelledby="raceSeriesDropdown">
-                {% for season in nav_race_series %}
-                  <li><h6 class="dropdown-header">{{ season.season }}</h6></li>
-                  {% for entry in season.series %}
-                    <li><a class="dropdown-item ms-3" href="{{ url_for('main.series_detail', series_id=entry.series.series_id) }}">{{ entry.series.name }}</a></li>
-                    {% for race in entry.races %}
-                    <li><a class="dropdown-item ms-5" href="{{ url_for('main.series_detail', series_id=entry.series.series_id, race_id=race.race_id) }}">{{ race.date }}</a></li>
-                    {% endfor %}
-                  {% endfor %}
-                  <li><hr class="dropdown-divider"></li>
-                {% endfor %}
-                <li><a class="dropdown-item" href="{{ url_for('main.series_index') }}">Series Index</a></li>
-                <li><a class="dropdown-item" href="{{ url_for('main.race_or_series_new') }}">Create New Race or Series</a></li>
-              </ul>
-            </li>
+            <li class="nav-item"><a class="nav-link" href="{{ url_for('main.races') }}">Races</a></li>
             <li class="nav-item dropdown">
               <a class="nav-link dropdown-toggle" href="#" id="standingsDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">Standings</a>
               <ul class="dropdown-menu" aria-labelledby="standingsDropdown">

--- a/app/templates/races.html
+++ b/app/templates/races.html
@@ -1,0 +1,20 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<h1>Races</h1>
+<table class="table table-hover">
+  <thead>
+    <tr><th>Date</th><th>Start time</th><th>Series</th><th># Finishers</th></tr>
+  </thead>
+  <tbody>
+    {% for race in races %}
+    <tr onclick="window.location='{{ url_for('main.race_sheet', race_id=race.race_id) }}'" style="cursor: pointer;">
+      <td>{{ race.date }}</td>
+      <td>{{ race.start_time or '' }}</td>
+      <td>{{ race.series_name }}</td>
+      <td>{{ race.finishers }}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -42,11 +42,13 @@ def test_series_detail_case_insensitive(client):
     assert res.status_code == 200
 
 
-def test_nav_links_use_canonical_series_id(client):
-    res = client.get('/race-series')
+def test_races_page_lists_races(client):
+    res = client.get('/races')
     html = res.get_data(as_text=True)
-    assert '/series/SER_2025_CASTF?race_id=RACE_2025-05-23_CastF_2' in html
-    assert '/series/SER_2025_CastF?race_id=RACE_2025-05-23_CastF_2' not in html
+    # earliest race date should appear before a later one
+    assert html.index('2025-04-26') < html.index('2025-05-16')
+    # rows link to individual race pages
+    assert '/races/RACE_2025-05-23_CastF_2' in html
 
 
 def test_race_sheet_redirects_to_canonical_series_id(client):


### PR DESCRIPTION
## Summary
- Replace "Race Series" dropdown with direct link to Races page
- Add `/races` route that lists all races with date, start time, series, and finisher count
- Make each race row link to the race detail page

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a183ebcba0832097b62d1cd2f91a56