### PR TITLE
Make races sortable and show series first

### DIFF
--- a/app/templates/races.html
+++ b/app/templates/races.html
@@ -2,19 +2,20 @@
 
 {% block content %}
 <h1>Races</h1>
-<table class="table table-hover">
+<table class="table table-hover sortable">
   <thead>
-    <tr><th>Date</th><th>Start time</th><th>Series</th><th># Finishers</th></tr>
+    <tr><th>Series</th><th>Date</th><th>Start time</th><th># Finishers</th></tr>
   </thead>
   <tbody>
     {% for race in races %}
     <tr onclick="window.location='{{ url_for('main.race_sheet', race_id=race.race_id) }}'" style="cursor: pointer;">
+      <td>{{ race.series_name }}</td>
       <td>{{ race.date }}</td>
       <td>{{ race.start_time or '' }}</td>
-      <td>{{ race.series_name }}</td>
       <td>{{ race.finishers }}</td>
     </tr>
     {% endfor %}
   </tbody>
 </table>
+<script src="https://www.kryogenix.org/code/browser/sorttable/sorttable.js"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Move series column to first position on the races page
- Enable client-side sorting for all race columns using sorttable

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a186ba40648320846c229fb79fdf9a