### PR TITLE
Add create race button to races page

### DIFF
--- a/app/templates/races.html
+++ b/app/templates/races.html
@@ -3,7 +3,7 @@
 {% block content %}
 <h1>Races</h1>
 <a class="btn btn-primary mb-3" href="{{ url_for('main.race_or_series_new') }}">Create New Race</a>
-<table class="table table-hover">
+<table class="table table-hover sortable">
   <thead>
     <tr><th>Date</th><th>Start time</th><th>Series</th><th># Finishers</th></tr>
   </thead>

--- a/app/templates/races.html
+++ b/app/templates/races.html
@@ -2,6 +2,7 @@
 
 {% block content %}
 <h1>Races</h1>
+<a class="btn btn-primary mb-3" href="{{ url_for('main.race_or_series_new') }}">Create New Race</a>
 <table class="table table-hover">
   <thead>
     <tr><th>Date</th><th>Start time</th><th>Series</th><th># Finishers</th></tr>

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -51,6 +51,13 @@ def test_races_page_lists_races(client):
     assert '/races/RACE_2025-05-23_CastF_2' in html
 
 
+def test_races_page_has_create_button(client):
+    res = client.get('/races')
+    html = res.get_data(as_text=True)
+    assert 'Create New Race' in html
+    assert 'href="/race-series/new"' in html
+
+
 def test_race_sheet_redirects_to_canonical_series_id(client):
     res = client.get('/races/RACE_2025-05-23_CastF_2', follow_redirects=False)
     assert res.status_code == 302


### PR DESCRIPTION
## Summary
- add "Create New Race" button linking to race creation form
- test for create-new-race button on races page

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a187430d088320b242fd16001cca46