### PR TITLE
Make races table sortable

### DIFF
--- a/app/static/sortable.js
+++ b/app/static/sortable.js
@@ -1,0 +1,23 @@
+document.addEventListener('DOMContentLoaded', function () {
+  document.querySelectorAll('table.sortable').forEach(function (table) {
+    const headers = table.querySelectorAll('th');
+    headers.forEach(function (header, index) {
+      header.style.cursor = 'pointer';
+      header.addEventListener('click', function () {
+        const tbody = table.querySelector('tbody');
+        const rows = Array.from(tbody.querySelectorAll('tr'));
+        const current = header.getAttribute('data-sort') || 'asc';
+        const direction = current === 'asc' ? 'desc' : 'asc';
+        headers.forEach(h => h.removeAttribute('data-sort'));
+        header.setAttribute('data-sort', direction);
+        rows.sort(function (a, b) {
+          const textA = a.children[index].innerText.trim();
+          const textB = b.children[index].innerText.trim();
+          const compare = textA.localeCompare(textB, undefined, {numeric: true});
+          return direction === 'asc' ? compare : -compare;
+        });
+        rows.forEach(row => tbody.appendChild(row));
+      });
+    });
+  });
+});

--- a/app/templates/races.html
+++ b/app/templates/races.html
@@ -18,5 +18,5 @@
     {% endfor %}
   </tbody>
 </table>
-<script src="https://www.kryogenix.org/code/browser/sorttable/sorttable.js"></script>
+<script src='{{ url_for('static', filename='sortable.js') }}'></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Add local JavaScript helper to sort tables
- Enable sortable columns on the Races page using the helper

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a18a762a8c832083e3a03dcda75f9e