### PR TITLE
Add sort icons to races table headers

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -10,6 +10,18 @@
         max-height: 70vh;
         overflow-y: auto;
       }
+
+      table.sortable th::after {
+        content: '\2195'; /* ↕ indicates sortable */
+        font-size: 0.8em;
+        margin-left: 0.25rem;
+      }
+      table.sortable th[data-sort="asc"]::after {
+        content: '\25B2'; /* ▲ ascending */
+      }
+      table.sortable th[data-sort="desc"]::after {
+        content: '\25BC'; /* ▼ descending */
+      }
     </style>
   </head>
   <body>


### PR DESCRIPTION
## Summary
- show visual sort indicators on sortable table columns

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a18b8367548320af2c23873df6b485