### PR TITLE
Enable sortable race results columns with icons

### DIFF
--- a/app/static/sortable.js
+++ b/app/static/sortable.js
@@ -1,19 +1,39 @@
+// Enable sorting for tables with the "sortable" class. Clicking a header
+// sorts by that column; clicking again reverses the order. Simple arrow icons
+// are added to indicate sortability and the current direction.
 document.addEventListener('DOMContentLoaded', function () {
   document.querySelectorAll('table.sortable').forEach(function (table) {
     const headers = table.querySelectorAll('th');
     headers.forEach(function (header, index) {
       header.style.cursor = 'pointer';
+
+      // Add sort indicator icon
+      const icon = document.createElement('span');
+      icon.className = 'ms-1 sort-icon';
+      icon.textContent = '↕';
+      header.appendChild(icon);
+
       header.addEventListener('click', function () {
         const tbody = table.querySelector('tbody');
         const rows = Array.from(tbody.querySelectorAll('tr'));
-        const current = header.getAttribute('data-sort') || 'asc';
+        const current = header.getAttribute('data-sort');
         const direction = current === 'asc' ? 'desc' : 'asc';
-        headers.forEach(h => h.removeAttribute('data-sort'));
+
+        headers.forEach(h => {
+          h.removeAttribute('data-sort');
+          const ic = h.querySelector('.sort-icon');
+          if (ic) {
+            ic.textContent = '↕';
+          }
+        });
+
         header.setAttribute('data-sort', direction);
+        icon.textContent = direction === 'asc' ? '▲' : '▼';
+
         rows.sort(function (a, b) {
           const textA = a.children[index].innerText.trim();
           const textB = b.children[index].innerText.trim();
-          const compare = textA.localeCompare(textB, undefined, {numeric: true});
+          const compare = textA.localeCompare(textB, undefined, { numeric: true });
           return direction === 'asc' ? compare : -compare;
         });
         rows.forEach(row => tbody.appendChild(row));

--- a/app/templates/series_detail.html
+++ b/app/templates/series_detail.html
@@ -67,6 +67,6 @@
     </tbody>
   </table>
 </div>
-<script src="https://www.kryogenix.org/code/browser/sorttable/sorttable.js"></script>
+<script src="{{ url_for('static', filename='sortable.js') }}"></script>
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- allow sorting by any column on race result tables
- toggle sort direction and show arrow icons indicating state
- use local sorting script across race pages

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a18c42cb48832084e4a44eb8b120f0