### PR TITLE
Remove duplicate sort icons on race tables

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -10,18 +10,6 @@
         max-height: 70vh;
         overflow-y: auto;
       }
-
-      table.sortable th::after {
-        content: '\2195'; /* ↕ indicates sortable */
-        font-size: 0.8em;
-        margin-left: 0.25rem;
-      }
-      table.sortable th[data-sort="asc"]::after {
-        content: '\25B2'; /* ▲ ascending */
-      }
-      table.sortable th[data-sort="desc"]::after {
-        content: '\25BC'; /* ▼ descending */
-      }
     </style>
   </head>
   <body>


### PR DESCRIPTION
## Summary
- drop CSS-generated sort indicators from base template to prevent duplicate icons
- tidy up style block

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a18d3a4a948320b9e85e275ec8e2cb