### PR TITLE
Ensure empty values sort last on race tables

### DIFF
--- a/app/static/sortable.js
+++ b/app/static/sortable.js
@@ -1,43 +1,62 @@
 // Enable sorting for tables with the "sortable" class. Clicking a header
 // sorts by that column; clicking again reverses the order. Simple arrow icons
 // are added to indicate sortability and the current direction.
-document.addEventListener('DOMContentLoaded', function () {
-  document.querySelectorAll('table.sortable').forEach(function (table) {
-    const headers = table.querySelectorAll('th');
-    headers.forEach(function (header, index) {
-      header.style.cursor = 'pointer';
 
-      // Add sort indicator icon
-      const icon = document.createElement('span');
-      icon.className = 'ms-1 sort-icon';
-      icon.textContent = '↕';
-      header.appendChild(icon);
+// Comparison helper that ensures empty strings always sort last.
+function compareValues(textA, textB, direction) {
+  const isEmptyA = textA === '';
+  const isEmptyB = textB === '';
+  if (isEmptyA && isEmptyB) return 0;
+  if (isEmptyA) return 1; // A should always go to the bottom
+  if (isEmptyB) return -1; // B should always go to the bottom
 
-      header.addEventListener('click', function () {
-        const tbody = table.querySelector('tbody');
-        const rows = Array.from(tbody.querySelectorAll('tr'));
-        const current = header.getAttribute('data-sort');
-        const direction = current === 'asc' ? 'desc' : 'asc';
+  const compare = textA.localeCompare(textB, undefined, { numeric: true });
+  return direction === 'asc' ? compare : -compare;
+}
 
-        headers.forEach(h => {
-          h.removeAttribute('data-sort');
-          const ic = h.querySelector('.sort-icon');
-          if (ic) {
-            ic.textContent = '↕';
-          }
+if (typeof document !== 'undefined') {
+  document.addEventListener('DOMContentLoaded', function () {
+    document.querySelectorAll('table.sortable').forEach(function (table) {
+      const headers = table.querySelectorAll('th');
+      headers.forEach(function (header, index) {
+        header.style.cursor = 'pointer';
+
+        // Add sort indicator icon
+        const icon = document.createElement('span');
+        icon.className = 'ms-1 sort-icon';
+        icon.textContent = '↕';
+        header.appendChild(icon);
+
+        header.addEventListener('click', function () {
+          const tbody = table.querySelector('tbody');
+          const rows = Array.from(tbody.querySelectorAll('tr'));
+          const current = header.getAttribute('data-sort');
+          const direction = current === 'asc' ? 'desc' : 'asc';
+
+          headers.forEach(h => {
+            h.removeAttribute('data-sort');
+            const ic = h.querySelector('.sort-icon');
+            if (ic) {
+              ic.textContent = '↕';
+            }
+          });
+
+          header.setAttribute('data-sort', direction);
+          icon.textContent = direction === 'asc' ? '▲' : '▼';
+
+          rows.sort(function (a, b) {
+            const textA = a.children[index].innerText.trim();
+            const textB = b.children[index].innerText.trim();
+            return compareValues(textA, textB, direction);
+          });
+          rows.forEach(row => tbody.appendChild(row));
         });
-
-        header.setAttribute('data-sort', direction);
-        icon.textContent = direction === 'asc' ? '▲' : '▼';
-
-        rows.sort(function (a, b) {
-          const textA = a.children[index].innerText.trim();
-          const textB = b.children[index].innerText.trim();
-          const compare = textA.localeCompare(textB, undefined, { numeric: true });
-          return direction === 'asc' ? compare : -compare;
-        });
-        rows.forEach(row => tbody.appendChild(row));
       });
     });
   });
-});
+}
+
+// Export for testing in Node environments
+if (typeof module !== 'undefined') {
+  module.exports = { compareValues };
+}

--- a/tests/test_sortable.js
+++ b/tests/test_sortable.js
@@ -1,0 +1,15 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { compareValues } = require('../app/static/sortable.js');
+
+test('ascending sort places empty strings last', () => {
+  const values = ['b', '', 'a'];
+  const sorted = values.slice().sort((a, b) => compareValues(a, b, 'asc'));
+  assert.deepStrictEqual(sorted, ['a', 'b', '']);
+});
+
+test('descending sort places empty strings last', () => {
+  const values = ['b', '', 'a'];
+  const sorted = values.slice().sort((a, b) => compareValues(a, b, 'desc'));
+  assert.deepStrictEqual(sorted, ['b', 'a', '']);
+});


### PR DESCRIPTION
## Summary
- Update table sorting to always place empty values last, regardless of sort direction
- Export sorting helper and add Node tests for ascending/descending behavior

## Testing
- `pytest -q`
- `node --test tests/test_sortable.js`


------
https://chatgpt.com/codex/tasks/task_e_68a18ed8c3008320a28c1a4a424c7907