### PR TITLE
Sort races index by date and start time by default

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -54,7 +54,14 @@ def _load_all_races():
                 "series_id": series_id,
                 "finishers": finishers,
             })
-    races.sort(key=lambda r: (r["date"] or "", r["start_time"] or ""))
+
+    def _sort_key(race):
+        """Sort by date then start time with blanks last."""
+        date = race.get("date") or ""
+        start = race.get("start_time") or ""
+        return (date == "", date, start == "", start)
+
+    races.sort(key=_sort_key)
     return races
 
 

--- a/app/static/sortable.js
+++ b/app/static/sortable.js
@@ -52,6 +52,19 @@ if (typeof document !== 'undefined') {
           rows.forEach(row => tbody.appendChild(row));
         });
       });
+
+      const defaultSort = table.getAttribute('data-sort-default');
+      if (defaultSort) {
+        const indices = defaultSort.split(',').map(s => parseInt(s.trim(), 10));
+        indices
+          .slice()
+          .reverse()
+          .forEach(i => {
+            if (headers[i]) {
+              headers[i].click();
+            }
+          });
+      }
     });
   });
 }

--- a/app/templates/races.html
+++ b/app/templates/races.html
@@ -3,7 +3,7 @@
 {% block content %}
 <h1>Races</h1>
 <a class="btn btn-primary mb-3" href="{{ url_for('main.race_or_series_new') }}">Create New Race</a>
-<table class="table table-hover sortable">
+<table class="table table-hover sortable" data-sort-default="1,2">
   <thead>
     <tr><th>Series</th><th>Date</th><th>Start time</th><th># Finishers</th></tr>
   </thead>

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -45,8 +45,16 @@ def test_series_detail_case_insensitive(client):
 def test_races_page_lists_races(client):
     res = client.get('/races')
     html = res.get_data(as_text=True)
-    # earliest race date should appear before a later one
-    assert html.index('2025-04-26') < html.index('2025-05-16')
+    # Table should be sorted by race date, then start time
+    import re
+    tbody = re.search(r'<tbody>(.*?)</tbody>', html, re.S).group(1)
+    rows = re.findall(r'<tr.*?>\s*(.*?)\s*</tr>', tbody, re.S)
+    pairs = []
+    for row_html in rows:
+        cells = re.findall(r'<td>(.*?)</td>', row_html)
+        if cells:
+            pairs.append((cells[1], cells[2]))
+    assert pairs == sorted(pairs)
     # rows link to individual race pages
     assert '/races/RACE_2025-05-23_CastF_2' in html
 


### PR DESCRIPTION
## Summary
- Ensure race listings are ordered by date then start time with blanks last
- Allow sortable tables to specify a default column order via `data-sort-default`
- Apply default sorting to races table
- Verify race page order respects date and start time

## Testing
- `pytest`
- `node tests/test_sortable.js`


------
https://chatgpt.com/codex/tasks/task_e_68a1950e473c83209f989501599156ed