### PR TITLE
Revamp race creation workflow

### DIFF
--- a/app/templates/race_form.html
+++ b/app/templates/race_form.html
@@ -1,24 +1,21 @@
 {% extends 'base.html' %}
 
 {% block content %}
-<h1>Create New Race or Series</h1>
+<h1>Create New Race</h1>
 <form method="post">
   <div class="mb-3">
     <label class="form-label">Series</label>
-    <select class="form-select" name="existing_series_id" id="existing_series_id">
-      <option value="">Create new series</option>
+    <select class="form-select" name="series_id" id="series_id" required>
+      <option value="" {% if not selected_series %}selected{% endif %}>Select Series or create new</option>
       {% for s in series_list %}
-        <option value="{{ s.series_id }}">{{ s.name }}</option>
+        <option value="{{ s.series_id }}" {% if selected_series == s.series_id %}selected{% endif %}>{{ s.name }}</option>
       {% endfor %}
+      <option value="__new__" {% if selected_series == '__new__' %}selected{% endif %}>Create New Series</option>
     </select>
   </div>
 
-  <div id="new-series-fields">
+  <div id="new-series-fields" style="display:none;">
     <h2>New Series Details</h2>
-    <div class="mb-3">
-      <label class="form-label">Series ID</label>
-      <input type="text" class="form-control" name="new_series_id">
-    </div>
     <div class="mb-3">
       <label class="form-label">Series Name</label>
       <input type="text" class="form-control" name="new_series_name">
@@ -31,28 +28,24 @@
 
   <h2>Race Details</h2>
   <div class="mb-3">
-    <label class="form-label">Race ID</label>
-    <input type="text" class="form-control" name="race_id">
-  </div>
-  <div class="mb-3">
-    <label class="form-label">Race Name</label>
-    <input type="text" class="form-control" name="race_name">
-  </div>
-  <div class="mb-3">
     <label class="form-label">Race Date</label>
-    <input type="date" class="form-control" name="race_date">
+    <input type="date" class="form-control" name="race_date" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Race Time</label>
+    <input type="text" class="form-control" name="race_time" pattern="^\d{2}:\d{2}:\d{2}$" placeholder="hh:mm:ss">
   </div>
   <button class="btn btn-primary">Save</button>
 </form>
 
 <script>
-  const seriesSelect = document.getElementById('existing_series_id');
+  const seriesSelect = document.getElementById('series_id');
   const newSeries = document.getElementById('new-series-fields');
   function toggleSeries() {
-    if (seriesSelect.value) {
-      newSeries.style.display = 'none';
-    } else {
+    if (seriesSelect.value === '__new__') {
       newSeries.style.display = 'block';
+    } else {
+      newSeries.style.display = 'none';
     }
   }
   seriesSelect.addEventListener('change', toggleSeries);

--- a/app/templates/races.html
+++ b/app/templates/races.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 <h1>Races</h1>
-<a class="btn btn-primary mb-3" href="{{ url_for('main.race_or_series_new') }}">Create New Race</a>
+<a class="btn btn-primary mb-3" href="{{ url_for('main.race_new') }}">Create New Race</a>
 <table class="table table-hover sortable">
   <thead>
     <tr><th>Series</th><th>Date</th><th>Start time</th><th># Finishers</th></tr>


### PR DESCRIPTION
## Summary
- Replace combined race/series creation with dedicated **Create New Race** page
- Allow creating a new series from a dropdown and auto-generate race & series IDs
- Validate optional race time (hh:mm:ss) and restrict race details to date/time
- Add tests confirming race creation persists JSON files

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a199355d5c8320b9bb6cce0c5a6464