### PR TITLE
Add responsive race header and dynamic series selector

### DIFF
--- a/app/templates/series_detail.html
+++ b/app/templates/series_detail.html
@@ -7,20 +7,48 @@
 </div>
 <div class="card mb-3">
   <div class="card-body">
-    <div class="mb-3">
-      <label class="form-label">Series Name</label>
-      <input type="text" id="series_name" class="form-control" value="{{ series.name }}" disabled>
+    <div class="row mb-3">
+      <label class="col-md-3 col-form-label">Series</label>
+      <div class="col-md-9">
+        <select class="form-select" id="series_id" disabled>
+          {% for s in series_list %}
+            <option value="{{ s.series_id }}" {% if series.series_id == s.series_id %}selected{% endif %}>{{ s.name }}</option>
+          {% endfor %}
+          <option value="__new__">Create New Series</option>
+        </select>
+      </div>
     </div>
-    <div class="mb-3">
-      <label class="form-label">Race Date</label>
-      <input type="date" id="race_date" class="form-control" value="{{ selected_race.date }}" disabled>
+    <div id="new-series-fields" style="display:none;">
+      <div class="row mb-3">
+        <label class="col-md-3 col-form-label">Series Name</label>
+        <div class="col-md-9">
+          <input type="text" id="new_series_name" class="form-control" disabled>
+        </div>
+      </div>
+      <div class="row mb-3">
+        <label class="col-md-3 col-form-label">Series Season</label>
+        <div class="col-md-9">
+          <input type="number" id="new_series_season" class="form-control" disabled>
+        </div>
+      </div>
     </div>
-    <div class="mb-3">
-      <label for="start_time" class="form-label">Start Time</label>
-      <input type="text" id="start_time" class="form-control" value="{{ selected_race.start_time }}" disabled>
+    <div class="row mb-3">
+      <label class="col-md-3 col-form-label">Race Date</label>
+      <div class="col-md-9">
+        <input type="date" id="race_date" class="form-control" value="{{ selected_race.date }}" disabled>
+      </div>
     </div>
-    <div class="mb-3">
-      <div id="finisherCount">{{ finisher_display }}</div>
+    <div class="row mb-3">
+      <label for="start_time" class="col-md-3 col-form-label">Start Time</label>
+      <div class="col-md-9">
+        <input type="text" id="start_time" class="form-control" value="{{ selected_race.start_time }}" disabled>
+      </div>
+    </div>
+    <div class="row mb-3">
+      <label class="col-md-3 col-form-label">Finishers</label>
+      <div class="col-md-9">
+        <div id="finisherCount">{{ finisher_display }}</div>
+      </div>
     </div>
   </div>
 </div>
@@ -105,14 +133,25 @@
 document.addEventListener('DOMContentLoaded', () => {
   let locked = true;
   const toggle = document.getElementById('editToggle');
-  const seriesName = document.getElementById('series_name');
+  const seriesSelect = document.getElementById('series_id');
+  const newSeriesFields = document.getElementById('new-series-fields');
+  const newSeriesName = document.getElementById('new_series_name');
+  const newSeriesSeason = document.getElementById('new_series_season');
   const raceDate = document.getElementById('race_date');
   const startTime = document.getElementById('start_time');
   const finishInputs = Array.from(document.querySelectorAll('.finish-time'));
   const finisherDiv = document.getElementById('finisherCount');
 
+  function toggleSeries() {
+    if (seriesSelect.value === '__new__') {
+      newSeriesFields.style.display = 'block';
+    } else {
+      newSeriesFields.style.display = 'none';
+    }
+  }
+
   function updateLocked() {
-    [seriesName, raceDate, startTime, ...finishInputs].forEach(inp => inp.disabled = locked);
+    [seriesSelect, newSeriesName, newSeriesSeason, raceDate, startTime, ...finishInputs].forEach(inp => inp.disabled = locked);
     toggle.textContent = locked ? '🔒' : '🔓';
   }
 
@@ -123,8 +162,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function saveChanges() {
     const payload = {
-      series_id: '{{ series.series_id }}',
-      series_name: seriesName.value,
+      series_id: seriesSelect.value,
+      new_series_name: newSeriesName.value,
+      new_series_season: newSeriesSeason.value,
       date: raceDate.value,
       start_time: startTime.value,
       finish_times: finishInputs.map(inp => ({competitor_id: inp.dataset.cid, finish_time: inp.value}))
@@ -135,6 +175,9 @@ document.addEventListener('DOMContentLoaded', () => {
       body: JSON.stringify(payload)
     }).then(r => r.json()).then(data => {
       finisherDiv.textContent = `Number of Finishers: ${data.finisher_count}`;
+      if (data.redirect) {
+        window.location = data.redirect;
+      }
     });
   }
 
@@ -143,17 +186,20 @@ document.addEventListener('DOMContentLoaded', () => {
     updateLocked();
   });
 
-  [seriesName, raceDate, startTime, ...finishInputs].forEach(inp => {
+  [seriesSelect, newSeriesName, newSeriesSeason, raceDate, startTime, ...finishInputs].forEach(inp => {
     inp.addEventListener('change', () => {
       computeFinishers();
+      toggleSeries();
       if (!locked) {
         saveChanges();
       }
     });
-    inp.addEventListener('input', computeFinishers);
   });
 
+  finishInputs.forEach(inp => inp.addEventListener('input', computeFinishers));
+
   computeFinishers();
+  toggleSeries();
   updateLocked();
 });
 </script>


### PR DESCRIPTION
## Summary
- make race detail header use two-column responsive layout
- allow selecting existing or new series from race page and move race if needed

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a19cdf51288320aca1bf555614bdbf