### PR TITLE
Display newest races first on index

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -54,7 +54,13 @@ def _load_all_races():
                 "series_id": series_id,
                 "finishers": finishers,
             })
-    races.sort(key=lambda r: (r["date"] or "", r["start_time"] or ""))
+    # Sort races by date and start time in descending order so the most recent
+    # race appears first in the list. Missing dates or times are treated as
+    # empty strings so they sort last.
+    races.sort(
+        key=lambda r: (r["date"] or "", r["start_time"] or ""),
+        reverse=True,
+    )
     return races
 
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -46,8 +46,8 @@ def test_series_detail_case_insensitive(client):
 def test_races_page_lists_races(client):
     res = client.get('/races')
     html = res.get_data(as_text=True)
-    # earliest race date should appear before a later one
-    assert html.index('2025-04-26') < html.index('2025-05-16')
+    # most recent race date should appear before earlier ones
+    assert html.index('2025-05-16') < html.index('2025-04-26')
     # rows link to individual race pages
     assert '/races/RACE_2025-05-23_CastF_2' in html
 


### PR DESCRIPTION
## Summary
- Sort races by date and start time in descending order
- Update tests for new default sort order

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a19d9d242c8320a13cceba324e32d1