### PR TITLE
Infer race season from race date for new series

### DIFF
--- a/app/templates/race_form.html
+++ b/app/templates/race_form.html
@@ -20,10 +20,6 @@
       <label class="form-label">Series Name</label>
       <input type="text" class="form-control" name="new_series_name">
     </div>
-    <div class="mb-3">
-      <label class="form-label">Series Season</label>
-      <input type="number" class="form-control" name="new_series_season">
-    </div>
   </div>
 
   <h2>Race Details</h2>

--- a/app/templates/series_detail.html
+++ b/app/templates/series_detail.html
@@ -25,12 +25,6 @@
           <input type="text" id="new_series_name" class="form-control" disabled>
         </div>
       </div>
-      <div class="row mb-3">
-        <label class="col-md-3 col-form-label">Series Season</label>
-        <div class="col-md-9">
-          <input type="number" id="new_series_season" class="form-control" disabled>
-        </div>
-      </div>
     </div>
     <div class="row mb-3">
       <label class="col-md-3 col-form-label">Race Date</label>
@@ -136,7 +130,6 @@ document.addEventListener('DOMContentLoaded', () => {
   const seriesSelect = document.getElementById('series_id');
   const newSeriesFields = document.getElementById('new-series-fields');
   const newSeriesName = document.getElementById('new_series_name');
-  const newSeriesSeason = document.getElementById('new_series_season');
   const raceDate = document.getElementById('race_date');
   const startTime = document.getElementById('start_time');
   const finishInputs = Array.from(document.querySelectorAll('.finish-time'));
@@ -151,7 +144,7 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function updateLocked() {
-    [seriesSelect, newSeriesName, newSeriesSeason, raceDate, startTime, ...finishInputs].forEach(inp => inp.disabled = locked);
+    [seriesSelect, newSeriesName, raceDate, startTime, ...finishInputs].forEach(inp => inp.disabled = locked);
     toggle.textContent = locked ? '🔒' : '🔓';
   }
 
@@ -164,7 +157,6 @@ document.addEventListener('DOMContentLoaded', () => {
     const payload = {
       series_id: seriesSelect.value,
       new_series_name: newSeriesName.value,
-      new_series_season: newSeriesSeason.value,
       date: raceDate.value,
       start_time: startTime.value,
       finish_times: finishInputs.map(inp => ({competitor_id: inp.dataset.cid, finish_time: inp.value}))
@@ -186,7 +178,7 @@ document.addEventListener('DOMContentLoaded', () => {
     updateLocked();
   });
 
-  [seriesSelect, newSeriesName, newSeriesSeason, raceDate, startTime, ...finishInputs].forEach(inp => {
+  [seriesSelect, newSeriesName, raceDate, startTime, ...finishInputs].forEach(inp => {
     inp.addEventListener('change', () => {
       computeFinishers();
       toggleSeries();

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -71,7 +71,6 @@ def test_create_new_race_creates_files(client, tmp_path, monkeypatch):
     res = client.post('/races/new', data={
         'series_id': '__new__',
         'new_series_name': 'Test',
-        'new_series_season': '2030',
         'race_date': '2030-01-01',
         'race_time': '12:30:45',
     })
@@ -80,6 +79,9 @@ def test_create_new_race_creates_files(client, tmp_path, monkeypatch):
     assert series_meta.exists()
     race_files = list((tmp_path / '2030' / 'Test' / 'races').glob('*.json'))
     assert len(race_files) == 1
+    with (tmp_path / '2030' / 'Test' / 'series_metadata.json').open() as f:
+        meta = json.load(f)
+    assert meta['season'] == 2030
     with race_files[0].open() as f:
         race_data = json.load(f)
     assert race_data['date'] == '2030-01-01'


### PR DESCRIPTION
## Summary
- Infer series season from the race date when creating or moving races, removing explicit season inputs
- Drop "Series Season" fields from new race form and race detail editor
- Adjust tests to cover season inference

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a19f04a1b083208e909852d3c2e985