### PR TITLE
Add race deletion with confirmation

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -454,3 +454,16 @@ def update_race(race_id):
 
     finisher_count = sum(1 for e in race_data.get('entrants', []) if e.get('finish_time'))
     return {'finisher_count': finisher_count, 'redirect': redirect_url}
+
+
+@bp.route('/api/races/<race_id>', methods=['DELETE'])
+def delete_race(race_id):
+    race_path = _race_path(race_id)
+    if race_path is None:
+        abort(404)
+    with race_path.open() as f:
+        race_data = json.load(f)
+    series_id = race_data.get('series_id')
+    race_path.unlink()
+    redirect_url = url_for('main.series_detail', series_id=series_id)
+    return {'redirect': redirect_url}

--- a/app/templates/series_detail.html
+++ b/app/templates/series_detail.html
@@ -150,6 +150,9 @@
     </tbody>
   </table>
   </div>
+  <div class="text-end mt-3">
+    <button type="button" class="btn btn-danger d-none" id="deleteRace">Delete Race</button>
+  </div>
 <div class="modal fade" id="confirmModal" tabindex="-1">
   <div class="modal-dialog modal-dialog-centered modal-fullscreen-sm-down">
     <div class="modal-content">
@@ -185,8 +188,10 @@ document.addEventListener('DOMContentLoaded', () => {
   const confirmModal = new bootstrap.Modal(confirmModalEl);
   const changeList = document.getElementById('changeList');
   const confirmSave = document.getElementById('confirmSave');
+  const deleteBtn = document.getElementById('deleteRace');
 
   let orig = {};
+  let pendingAction = null;
 
   function captureOrig() {
     orig = {
@@ -242,6 +247,7 @@ document.addEventListener('DOMContentLoaded', () => {
     [seriesSelect, newSeriesName, raceDate, startTime, ...finishInputs].forEach(inp => inp.disabled = locked);
     toggle.textContent = locked ? '🔒' : '🔓';
     updateButtons();
+    deleteBtn.classList.toggle('d-none', locked);
   }
 
   function computeFinishers() {
@@ -327,17 +333,41 @@ document.addEventListener('DOMContentLoaded', () => {
       li.textContent = ch;
       changeList.appendChild(li);
     });
+    pendingAction = 'save';
     confirmModal.show();
   });
 
   confirmSave.addEventListener('click', () => {
-    saveChanges().then(() => {
-      captureOrig();
-      locked = true;
-      updateLocked();
-      confirmModal.hide();
-    });
+    if (pendingAction === 'delete') {
+      deleteRace().then(data => {
+        if (data.redirect) {
+          window.location = data.redirect;
+        }
+      });
+    } else {
+      saveChanges().then(() => {
+        captureOrig();
+        locked = true;
+        updateLocked();
+      });
+    }
+    confirmModal.hide();
   });
+
+  deleteBtn.addEventListener('click', () => {
+    changeList.innerHTML = '';
+    const li = document.createElement('li');
+    li.textContent = 'This race will be permanently deleted.';
+    changeList.appendChild(li);
+    pendingAction = 'delete';
+    confirmModal.show();
+  });
+
+  function deleteRace() {
+    return fetch('{{ url_for('main.delete_race', race_id=selected_race.race_id) }}', {
+      method: 'DELETE'
+    }).then(r => r.json());
+  }
 
   computeFinishers();
   toggleSeries();

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -92,6 +92,33 @@ def test_create_new_race_creates_files(client, tmp_path, monkeypatch):
     assert race_data['race_id'].startswith('RACE_2030-01-01_Test_')
 
 
+def test_delete_race_removes_file(client, tmp_path, monkeypatch):
+    from app import routes
+    monkeypatch.setattr(routes, 'DATA_DIR', tmp_path)
+    sdir = tmp_path / '2030' / 'Test'
+    (sdir / 'races').mkdir(parents=True)
+    (sdir / 'series_metadata.json').write_text(json.dumps({
+        'series_id': 'SER_2030_Test',
+        'name': 'Test',
+        'season': 2030,
+    }))
+    race_id = 'RACE_2030-01-01_Test_1'
+    race_path = sdir / 'races' / f'{race_id}.json'
+    race_path.write_text(json.dumps({
+        'race_id': race_id,
+        'series_id': 'SER_2030_Test',
+        'name': 'Race',
+        'date': '2030-01-01',
+        'start_time': '10:00:00',
+        'entrants': [],
+    }))
+    res = client.delete(f'/api/races/{race_id}')
+    assert res.status_code == 200
+    assert not race_path.exists()
+    data = res.get_json()
+    assert data['redirect']
+
+
 def test_races_page_can_filter_by_season(client, tmp_path, monkeypatch):
     from app import routes
     monkeypatch.setattr(routes, 'DATA_DIR', tmp_path)


### PR DESCRIPTION
## Summary
- Add a Delete Race button on the race detail page that appears when unlocked and reuses the confirmation modal
- Implement DELETE /api/races/<race_id> endpoint to remove race JSON and redirect
- Test race deletion API

## Testing
- `pytest`
- `node tests/test_sortable.js`


------
https://chatgpt.com/codex/tasks/task_e_68a1a8c101f083209e89df5829eb14d5