### PR TITLE
Populate non-finisher race stats

### DIFF
--- a/app/scoring.py
+++ b/app/scoring.py
@@ -152,9 +152,10 @@ def calculate_race_results(entries: Iterable[Dict]) -> List[Dict]:
         entry.update(
             {
                 "handicap_position": None,
-                "full_delta": None,
-                "scaled_delta": None,
-                "actual_delta": None,
+                # For non-finishers, handicaps and points do not change
+                "full_delta": 0,
+                "scaled_delta": 0,
+                "actual_delta": 0,
                 "revised_handicap": entry.get("initial_handicap"),
                 "points": 0.0,
                 "traditional_points": non_finisher_points,

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -114,6 +114,13 @@ def test_traditional_points_and_standings():
     assert [r["traditional_points"] for r in race1] == [1, 2, 3]
     assert [r["traditional_points"] for r in race2] == [1, 2, 3]
 
+    # Non-finishers should retain their handicap and score default points
+    dnf_entry = race1[2]
+    assert dnf_entry["full_delta"] == 0
+    assert dnf_entry["actual_delta"] == 0
+    assert dnf_entry["revised_handicap"] == 300
+    assert dnf_entry["points"] == 0.0
+
     standings = compute_traditional_standings([race1, race2])
     totals = {s["sailor"]: s["total_points"] for s in standings}
     assert totals["A"] == 3


### PR DESCRIPTION
## Summary
- Ensure non-finishers receive zero handicap changes and league points
- Keep non-finishers' revised handicap equal to initial handicap
- Test that non-finishers retain handicaps and score default points

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1aa55f0748320a7d67368a353df34