### PR TITLE
Show fleet adjustment percent on race page

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -3,7 +3,7 @@ import json
 from datetime import datetime
 from pathlib import Path
 
-from .scoring import calculate_race_results
+from .scoring import calculate_race_results, _scaling_factor
 
 
 bp = Blueprint('main', __name__)
@@ -166,6 +166,7 @@ def race_new():
         fleet=fleet,
         series_list=series_list,
         unlocked=True,
+        fleet_adjustment=0,
     )
 
 
@@ -182,6 +183,7 @@ def series_detail(series_id):
     selected_race = None
     finisher_count = 0
     fleet = []
+    fleet_adjustment = 0
 
     def _parse_hms(t: str | None) -> int | None:
         if not t:
@@ -224,6 +226,8 @@ def series_detail(series_id):
 
             results_list = calculate_race_results(calc_entries)
             finisher_count = sum(1 for r in results_list if r.get('finish') is not None)
+            if finisher_count:
+                fleet_adjustment = int(round(_scaling_factor(finisher_count) * 100))
             results: dict[str, dict] = {}
             for res in results_list:
                 cid = res.get('competitor_id')
@@ -282,6 +286,7 @@ def series_detail(series_id):
         finisher_display=finisher_display,
         fleet=fleet,
         series_list=series_list,
+        fleet_adjustment=fleet_adjustment,
     )
 
 

--- a/app/templates/series_detail.html
+++ b/app/templates/series_detail.html
@@ -120,6 +120,7 @@
         <th style="width: 110px;">Hcp Allowance (s)</th>
         <th style="width: 120px;">Adj Time (hh:mm:ss)</th>
         <th style="width: 120px;">Full Hcp Change (s/hr)</th>
+        <th style="width: 120px;">Fleet Adjustment (%)</th>
         <th style="width: 140px;">Adjusted Hcp Change (s/hr)</th>
         <th style="width: 110px;">Revised Hcp (s/hr)</th>
         <th style="width: 90px;">Race Pts (Traditional)</th>
@@ -141,6 +142,7 @@
         <td>{{ result.allowance|round|int if result.allowance is defined and result.allowance is not none else '' }}</td>
         <td>{{ result.adj_time or '' }}</td>
         <td>{{ result.full_delta|round|int if result.full_delta is defined and result.full_delta is not none else '' }}</td>
+        <td>{{ fleet_adjustment if fleet_adjustment is not none else '' }}</td>
         <td>{{ result.actual_delta|round|int if result.actual_delta is defined and result.actual_delta is not none else '' }}</td>
         <td>{{ result.revised_hcp|round|int if result.revised_hcp is defined and result.revised_hcp is not none else '' }}</td>
         <td>{{ result.race_pts|round|int if result.race_pts is defined and result.race_pts is not none else '' }}</td>

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -37,6 +37,13 @@ def test_race_page_calculates_results(client):
     assert '01:24:53' in html  # adjusted time hh:mm:ss
 
 
+def test_race_page_shows_fleet_adjustment(client):
+    res = client.get('/series/SER_2025_MYHF?race_id=RACE_2025-07-11_MYHF_1')
+    html = res.get_data(as_text=True)
+    assert 'Fleet Adjustment (%)' in html
+    assert '<td>100</td>' in html
+
+
 def test_series_detail_case_insensitive(client):
     """Series routes should be accessible regardless of ID casing."""
     res = client.get('/series/ser_2025_myhf?race_id=RACE_2025-07-11_MYHF_1')


### PR DESCRIPTION
## Summary
- Display Fleet Adjustment (%) for each race using fleet-size scaling table
- Compute fleet adjustment percentage in routes and render new column in race table
- Add test ensuring fleet adjustment column appears

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1adff5d188320a338e6b3afb78072