### PR TITLE
Persist settings updates via API

### DIFF
--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -9,7 +9,7 @@
   <div class="row g-4">
     <div class="col-lg-4">
       <h2 class="h5">Base Handicap Change by Rank</h2>
-      <table class="table table-sm table-bordered">
+      <table id="handicapTable" class="table table-sm table-bordered">
         <thead>
           <tr><th>Rank</th><th>Δ (s/hr)</th><th class="edit-only d-none"></th></tr>
         </thead>
@@ -27,7 +27,7 @@
     </div>
     <div class="col-lg-4">
       <h2 class="h5">League Points by Rank</h2>
-      <table class="table table-sm table-bordered">
+      <table id="leagueTable" class="table table-sm table-bordered">
         <thead>
           <tr><th>Rank</th><th>Points</th><th class="edit-only d-none"></th></tr>
         </thead>
@@ -45,7 +45,7 @@
     </div>
     <div class="col-lg-4">
       <h2 class="h5">Fleet-size Scaling</h2>
-      <table class="table table-sm table-bordered">
+      <table id="fleetTable" class="table table-sm table-bordered">
         <thead>
           <tr><th>Finishers</th><th>Factor</th><th class="edit-only d-none"></th></tr>
         </thead>
@@ -105,6 +105,45 @@ document.addEventListener('DOMContentLoaded', () => {
       attachRemove(tr.querySelector('.remove-row'));
       updateLocked();
     });
+  });
+
+  function toValue(str) {
+    if (str === '') return null;
+    const num = Number(str);
+    return isNaN(num) ? str : num;
+  }
+
+  function parseTable(table, keys) {
+    const rows = [];
+    table.querySelectorAll('tbody tr').forEach(tr => {
+      const inputs = tr.querySelectorAll('input');
+      const first = toValue(inputs[0].value.trim());
+      const second = toValue(inputs[1].value.trim());
+      if (first !== null && second !== null) {
+        const obj = {};
+        obj[keys[0]] = first;
+        obj[keys[1]] = second;
+        rows.push(obj);
+      }
+    });
+    return rows;
+  }
+
+  saveBtn.addEventListener('click', async (e) => {
+    e.preventDefault();
+    const payload = {
+      handicap_delta_by_rank: parseTable(document.getElementById('handicapTable'), ['rank', 'delta_s_per_hr']),
+      league_points_by_rank: parseTable(document.getElementById('leagueTable'), ['rank', 'points']),
+      fleet_size_factor: parseTable(document.getElementById('fleetTable'), ['finishers', 'factor'])
+    };
+    const res = await fetch('/api/settings', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify(payload)
+    });
+    if (res.ok) {
+      location.reload();
+    }
   });
 
   updateLocked();

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -209,3 +209,42 @@ def test_race_page_shows_defaults_for_non_finishers(client, tmp_path, monkeypatc
     assert '>0</td>' in html  # Full/adjusted handicap change or league pts
     assert '>100</td>' in html  # Revised handicap equals initial handicap
     assert '>1</td>' in html  # Traditional points = finishers + 1 (0 + 1)
+
+
+def test_settings_save_updates_json_and_page(client, tmp_path, monkeypatch):
+    from app import routes
+
+    monkeypatch.setattr(routes, 'DATA_DIR', tmp_path)
+    settings_path = tmp_path / 'settings.json'
+    original = {
+        'version': 1,
+        'updated_at': '2025-01-01T00:00:00Z',
+        'handicap_delta_by_rank': [{'rank': 1, 'delta_s_per_hr': -10}],
+        'league_points_by_rank': [{'rank': 1, 'points': 5}],
+        'fleet_size_factor': [{'finishers': 1, 'factor': 0.5}],
+    }
+    settings_path.write_text(json.dumps(original))
+
+    res = client.get('/settings')
+    html = res.get_data(as_text=True)
+    assert 'value="-10"' in html
+
+    new_data = {
+        'handicap_delta_by_rank': [{'rank': 1, 'delta_s_per_hr': -5}],
+        'league_points_by_rank': [{'rank': 1, 'points': 9}],
+        'fleet_size_factor': [{'finishers': 1, 'factor': 0.9}],
+    }
+    res = client.post('/api/settings', json=new_data)
+    assert res.status_code == 200
+
+    with settings_path.open() as f:
+        saved = json.load(f)
+    assert saved['handicap_delta_by_rank'][0]['delta_s_per_hr'] == -5
+    assert saved['league_points_by_rank'][0]['points'] == 9
+    assert saved['fleet_size_factor'][0]['factor'] == 0.9
+
+    res = client.get('/settings')
+    html = res.get_data(as_text=True)
+    assert 'value="-5"' in html
+    assert 'value="9"' in html
+    assert 'value="0.9"' in html


### PR DESCRIPTION
## Summary
- add `/api/settings` endpoint to write updated settings.json and reload scoring
- enable Settings page to post table values and reload once saved
- test that saving settings updates the JSON and rendered page

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1ae55c98883209c0577fc28b2cda0