### PR TITLE
Ensure race sheet fields populated for non-finishers

### DIFF
--- a/app/scoring.py
+++ b/app/scoring.py
@@ -96,8 +96,15 @@ def calculate_race_results(entries: Iterable[Dict]) -> List[Dict]:
         status = entry.get("status")
         finish = entry.get("finish")
         if status in {"DNF", "DNS", "DSQ"} or finish is None:
-            # Record the entry without timing information
-            non_finishers.append({**entry, "status": status})
+            # Record the entry with zeroed timing values so downstream
+            # consumers can display consistent fields for all boats even when
+            # they do not finish.
+            times = {
+                "elapsed_seconds": 0,
+                "allowance_seconds": 0.0,
+                "adjusted_time_seconds": 0.0,
+            }
+            non_finishers.append({**entry, **times, "status": status, "finish": None})
             continue
 
         times = adjusted_time(entry["start"], finish, entry["initial_handicap"])

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -127,3 +127,26 @@ def test_traditional_points_and_standings():
     assert totals["B"] == 5
     assert totals["C"] == 4
     assert [s["sailor"] for s in standings] == ["A", "C", "B"]
+
+
+def test_non_finisher_includes_zeroed_fields():
+    entries = [
+        {
+            "sailor": "A",
+            "boat": "",
+            "sail_number": 1,
+            "start": 0,
+            "initial_handicap": 300,
+            "status": "DNF",
+        }
+    ]
+    results = calculate_race_results(entries)
+    res = results[0]
+    assert res["elapsed_seconds"] == 0
+    assert res["allowance_seconds"] == 0.0
+    assert res["adjusted_time_seconds"] == 0.0
+    assert res["full_delta"] == 0
+    assert res["actual_delta"] == 0
+    assert res["revised_handicap"] == 300
+    assert res["points"] == 0.0
+    assert res["traditional_points"] == 1


### PR DESCRIPTION
## Summary
- Always include zeroed timing metrics for DNF/DNS/DSQ entrants
- Add regression test covering non-finisher result fields

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1b5b16ca8832091ead52de4fd49eb