### PR TITLE
Add race navigation dropdown

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -344,7 +344,15 @@ def series_detail(series_id):
 
     finisher_display = f"Number of Finishers: {finisher_count}"
 
-    breadcrumbs = [('Races', url_for('main.races')), (series.get('name', series_id), None)]
+    # When viewing an individual race, suppress breadcrumbs and provide a list
+    # of all races for navigation. Otherwise show the standard breadcrumb trail.
+    if selected_race:
+        breadcrumbs = None
+        all_races = _load_all_races()
+    else:
+        breadcrumbs = [('Races', url_for('main.races')), (series.get('name', series_id), None)]
+        all_races = []
+
     series_list = [entry['series'] for entry in _load_series_entries()]
     return render_template(
         'series_detail.html',
@@ -357,6 +365,7 @@ def series_detail(series_id):
         fleet=fleet,
         series_list=series_list,
         fleet_adjustment=fleet_adjustment,
+        all_races=all_races,
     )
 
 

--- a/app/templates/series_detail.html
+++ b/app/templates/series_detail.html
@@ -2,6 +2,14 @@
 
 {% block content %}
 {% if selected_race %}
+<div class="d-flex align-items-center mb-3">
+  <a href="{{ url_for('main.races') }}">Races</a>
+  <select class="form-select w-auto ms-2" onchange="window.location=this.value">
+    {% for race in all_races %}
+      <option value="{{ url_for('main.race_sheet', race_id=race.race_id) }}" {% if race.race_id == selected_race.race_id %}selected{% endif %}>{{ race.date }} {{ race.start_time or '' }} ({{ race.series_name }})</option>
+    {% endfor %}
+  </select>
+</div>
 <div class="d-flex justify-content-end mb-2">
   <button type="button" class="btn btn-success me-2 d-none" id="saveChanges">Save Changes</button>
   <button type="button" class="btn btn-danger me-2 d-none" id="cancelChanges">Cancel Changes</button>

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -44,6 +44,21 @@ def test_race_page_shows_fleet_adjustment(client):
     assert '<td>100</td>' in html
 
 
+def test_race_page_has_dropdown_navigation(client):
+    res = client.get('/series/SER_2025_MYHF?race_id=RACE_2025-07-11_MYHF_1')
+    html = res.get_data(as_text=True)
+    # Breadcrumbs should be absent and replaced with a link and dropdown
+    assert '<ol class="breadcrumb">' not in html
+    assert '<a href="/races">Races</a>' in html
+    assert 'onchange="window.location=this.value"' in html
+    # Dropdown should list races in descending order by date/time
+    assert '2025-09-21 00:00:00 (CastS)' in html
+    assert '2025-09-14 00:00:00 (CastS)' in html
+    assert html.index('2025-09-21 00:00:00 (CastS)') < html.index('2025-09-14 00:00:00 (CastS)')
+    # Currently viewed race should be selected
+    assert 'selected>2025-07-11 18:25:00 (MYHF)</option>' in html
+
+
 def test_series_detail_case_insensitive(client):
     """Series routes should be accessible regardless of ID casing."""
     res = client.get('/series/ser_2025_myhf?race_id=RACE_2025-07-11_MYHF_1')


### PR DESCRIPTION
## Summary
- Replace breadcrumbs on race pages with a "Races" link and race selector dropdown.
- Populate dropdown with all races sorted by date and time, and navigate on selection.
- Add test coverage for new race navigation UI.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1d76382548320b0340408a13fdce3