### PR TITLE
Add collapsible per-race columns to standings

### DIFF
--- a/app/templates/standings.html
+++ b/app/templates/standings.html
@@ -21,14 +21,32 @@
 </form>
 <div class="table-responsive">
   <table class="table table-striped table-sm">
+    {% set ns = namespace(count=0) %}
+    {% for g in race_groups %}
+      {% set ns.count = ns.count + (g.races|length) %}
+    {% endfor %}
     <thead>
       <tr>
-        <th>Position</th>
-        <th>Sailor</th>
-        <th>Boat</th>
-        <th>Sail No.</th>
-        <th># Races</th>
-        <th>Total Points</th>
+        <th rowspan="2">Position</th>
+        <th rowspan="2">Sailor</th>
+        <th rowspan="2">Boat</th>
+        <th rowspan="2">Sail No.</th>
+        <th rowspan="2"># Races</th>
+        {% for group in race_groups %}
+        {% set idx = loop.index0 %}
+        <th class="text-center" colspan="{{ group.races|length }}">
+          <button type="button" class="btn btn-link p-0 series-toggle" data-series="{{ idx }}">{{ group.series_name }}</button>
+        </th>
+        {% endfor %}
+        <th rowspan="2">Total Points</th>
+      </tr>
+      <tr>
+        {% for group in race_groups %}
+          {% set idx = loop.index0 %}
+          {% for race in group.races %}
+          <th class="series-{{ idx }}">{{ race.date }} {{ race.start_time }}</th>
+          {% endfor %}
+        {% endfor %}
       </tr>
     </thead>
     <tbody>
@@ -39,12 +57,29 @@
         <td>{{ row.boat }}</td>
         <td>{{ row.sail_number }}</td>
         <td>{{ row.race_count }}</td>
+        {% for group in race_groups %}
+          {% set idx = loop.index0 %}
+          {% for race in group.races %}
+            {% set pts = row.race_points.get(race.race_id) %}
+            <td class="series-{{ idx }}">{% if pts is not none %}{{ '%.1f'|format(pts) }}{% else %}&nbsp;{% endif %}</td>
+          {% endfor %}
+        {% endfor %}
         <td>{{ '%.1f'|format(row.total_points) }}</td>
       </tr>
       {% else %}
-      <tr><td colspan="6" class="text-muted">No data.</td></tr>
+      <tr><td colspan="{{ 6 + ns.count }}" class="text-muted">No data.</td></tr>
       {% endfor %}
     </tbody>
   </table>
 </div>
+<script>
+  document.querySelectorAll('.series-toggle').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const idx = btn.dataset.series;
+      document.querySelectorAll('.series-' + idx).forEach(el => {
+        el.classList.toggle('d-none');
+      });
+    });
+  });
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- compute race groups and per-race points in standings data
- show race-by-race points grouped by series with collapsible columns

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a1e8b049ac8320aa20f0962c735c3a