### PR TITLE
Enhance standings layout with series totals and toggles

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -257,7 +257,7 @@ def _season_standings(season: int, scoring: str) -> tuple[list[dict], list[dict]
     race_groups.sort(key=lambda g: g["series_name"] or "")
 
     aggregates: dict[str, dict] = {}
-    for group in race_groups:
+    for idx, group in enumerate(race_groups):
         for race in group["races"]:
             for res in race["results"]:
                 cid = res.get("competitor_id")
@@ -271,6 +271,7 @@ def _season_standings(season: int, scoring: str) -> tuple[list[dict], list[dict]
                         "league_points": 0.0,
                         "traditional_points": 0.0,
                         "race_points": {},
+                        "series_totals": {},
                     },
                 )
                 if res.get("finish") is not None:
@@ -281,6 +282,7 @@ def _season_standings(season: int, scoring: str) -> tuple[list[dict], list[dict]
                 agg["traditional_points"] += trad_pts
                 pts = league_pts if scoring == "league" else trad_pts
                 agg["race_points"][race["race_id"]] = pts
+                agg["series_totals"][idx] = agg["series_totals"].get(idx, 0.0) + pts
 
     standings: list[dict] = []
     for agg in aggregates.values():
@@ -299,6 +301,7 @@ def _season_standings(season: int, scoring: str) -> tuple[list[dict], list[dict]
                 "race_count": agg["race_count"],
                 "total_points": total,
                 "race_points": agg["race_points"],
+                "series_totals": agg["series_totals"],
             }
         )
 

--- a/app/templates/standings.html
+++ b/app/templates/standings.html
@@ -19,12 +19,31 @@
     </select>
   </div>
 </form>
+{% set ns = namespace(count=0) %}
+{% for g in race_groups %}
+  {% set ns.count = ns.count + (g.races|length) %}
+{% endfor %}
+{% set colour_classes = ['bg-primary-subtle','bg-secondary-subtle','bg-success-subtle','bg-info-subtle','bg-warning-subtle','bg-danger-subtle'] %}
+
+<style>
+  .series-boundary {
+    border-left: 2px solid var(--bs-border-color);
+  }
+</style>
+
+<div class="mb-2">
+  {% for group in race_groups %}
+    {% set idx = loop.index0 %}
+    {% set colour_class = colour_classes[idx % (colour_classes|length)] %}
+    <div class="form-check form-check-inline">
+      <input class="form-check-input series-toggle" type="checkbox" id="seriesToggle{{ idx }}" data-series="{{ idx }}" checked>
+      <label class="form-check-label {{ colour_class }} px-1 rounded" for="seriesToggle{{ idx }}">{{ group.series_name }}</label>
+    </div>
+  {% endfor %}
+</div>
+
 <div class="table-responsive">
   <table class="table table-striped table-sm">
-    {% set ns = namespace(count=0) %}
-    {% for g in race_groups %}
-      {% set ns.count = ns.count + (g.races|length) %}
-    {% endfor %}
     <thead>
       <tr>
         <th rowspan="2">Position</th>
@@ -34,18 +53,19 @@
         <th rowspan="2"># Races</th>
         {% for group in race_groups %}
         {% set idx = loop.index0 %}
-        <th class="text-center" colspan="{{ group.races|length }}">
-          <button type="button" class="btn btn-link p-0 series-toggle" data-series="{{ idx }}">{{ group.series_name }}</button>
-        </th>
+        {% set colour_class = colour_classes[idx % (colour_classes|length)] %}
+        <th class="text-center series-group {{ colour_class }}{% if not loop.first %} series-boundary{% endif %}" colspan="{{ group.races|length + 1 }}">{{ group.series_name }}</th>
         {% endfor %}
-        <th rowspan="2">Total Points</th>
+        <th rowspan="2" class="fw-bold">Total Points</th>
       </tr>
       <tr>
         {% for group in race_groups %}
           {% set idx = loop.index0 %}
+          {% set colour_class = colour_classes[idx % (colour_classes|length)] %}
           {% for race in group.races %}
-          <th class="series-{{ idx }}">{{ race.date }} {{ race.start_time }}</th>
+          <th class="series-{{ idx }} {{ colour_class }}{% if loop.index0 == 0 and idx > 0 %} series-boundary{% endif %}">{{ race.date }} {{ race.start_time[:5] if race.start_time }}</th>
           {% endfor %}
+          <th class="{{ colour_class }}{% if idx > 0 %} series-boundary{% endif %}">Total</th>
         {% endfor %}
       </tr>
     </thead>
@@ -59,25 +79,28 @@
         <td>{{ row.race_count }}</td>
         {% for group in race_groups %}
           {% set idx = loop.index0 %}
+          {% set colour_class = colour_classes[idx % (colour_classes|length)] %}
           {% for race in group.races %}
             {% set pts = row.race_points.get(race.race_id) %}
-            <td class="series-{{ idx }}">{% if pts is not none %}{{ '%.1f'|format(pts) }}{% else %}&nbsp;{% endif %}</td>
+            <td class="series-{{ idx }}{% if loop.index0 == 0 and idx > 0 %} series-boundary{% endif %}">{% if pts is not none %}{{ '%.1f'|format(pts) }}{% else %}&nbsp;{% endif %}</td>
           {% endfor %}
+          {% set total = row.series_totals.get(idx) %}
+          <td class="{{ colour_class }}{% if idx > 0 %} series-boundary{% endif %}">{% if total is not none %}{{ '%.1f'|format(total) }}{% else %}&nbsp;{% endif %}</td>
         {% endfor %}
-        <td>{{ '%.1f'|format(row.total_points) }}</td>
+        <td class="fw-bold">{{ '%.1f'|format(row.total_points) }}</td>
       </tr>
       {% else %}
-      <tr><td colspan="{{ 6 + ns.count }}" class="text-muted">No data.</td></tr>
+      <tr><td colspan="{{ 6 + ns.count + (race_groups|length) }}" class="text-muted">No data.</td></tr>
       {% endfor %}
     </tbody>
   </table>
 </div>
 <script>
-  document.querySelectorAll('.series-toggle').forEach(btn => {
-    btn.addEventListener('click', () => {
-      const idx = btn.dataset.series;
+  document.querySelectorAll('.series-toggle').forEach(cb => {
+    cb.addEventListener('change', () => {
+      const idx = cb.dataset.series;
       document.querySelectorAll('.series-' + idx).forEach(el => {
-        el.classList.toggle('d-none');
+        el.classList.toggle('d-none', !cb.checked);
       });
     });
   });


### PR DESCRIPTION
## Summary
- Distinguish series groups with color-coded headers and vertical separators
- Show race start times in `hh:mm` format
- Allow race-by-race columns to be hidden or shown via checkboxes
- Keep per-series totals visible and bold the overall points column

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a2046b75688320a35c951bba26fc3c