### PR TITLE
Fix standings table header alignment with series toggle

### DIFF
--- a/app/templates/standings.html
+++ b/app/templates/standings.html
@@ -54,7 +54,7 @@
         {% for group in race_groups %}
         {% set idx = loop.index0 %}
         {% set colour_class = colour_classes[idx % (colour_classes|length)] %}
-        <th class="text-center series-group {{ colour_class }}{% if not loop.first %} series-boundary{% endif %}" colspan="{{ group.races|length + 1 }}">{{ group.series_name }}</th>
+        <th class="text-center series-group {{ colour_class }}{% if not loop.first %} series-boundary{% endif %}" data-series="{{ idx }}" colspan="{{ group.races|length + 1 }}">{{ group.series_name }}</th>
         {% endfor %}
         <th rowspan="2" class="fw-bold">Total Points</th>
       </tr>
@@ -102,6 +102,11 @@
       document.querySelectorAll('.series-' + idx).forEach(el => {
         el.classList.toggle('d-none', !cb.checked);
       });
+      const header = document.querySelector('.series-group[data-series="' + idx + '"]');
+      if (header) {
+        const visibleRaces = document.querySelectorAll('th.series-' + idx + ':not(.d-none)').length;
+        header.colSpan = visibleRaces + 1;
+      }
     });
   });
 </script>


### PR DESCRIPTION
## Summary
- Adjust standings template so series headers track visible race columns
- Update series toggle JS to set the appropriate colspan

## Testing
- `python -m pytest`
- `node tests/test_sortable.js`


------
https://chatgpt.com/codex/tasks/task_e_68a23c60f5408320b3308bbc27df29bb