### PR TITLE
Add note above standings series columns

### DIFF
--- a/app/templates/standings.html
+++ b/app/templates/standings.html
@@ -43,6 +43,10 @@
   <table class="table table-striped table-sm">
     <thead>
       <tr>
+        <th colspan="6"></th>
+        <th colspan="{{ ns.count + (race_groups|length) }}" class="text-center">Series results (click to see individual race scores):</th>
+      </tr>
+      <tr>
         <th rowspan="2">Position</th>
         <th rowspan="2">Sailor</th>
         <th rowspan="2">Boat</th>


### PR DESCRIPTION
## Summary
- Clarify standings table by adding a header note above series columns encouraging users to click for individual race scores.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a242ce9a9083209c07f0108b359772