### PR TITLE
Fix standings column widths and sticky headers

### DIFF
--- a/app/templates/standings.html
+++ b/app/templates/standings.html
@@ -37,10 +37,47 @@
     transform: rotate(180deg);
     white-space: nowrap;
   }
+  .standings-table thead tr:nth-child(2) th:not(.series-group),
+  .standings-table thead tr:nth-child(3) th,
+  .standings-table tbody td {
+    width: 65px;
+    min-width: 65px;
+    max-width: 65px;
+  }
+  .standings-table th.sailor-col,
+  .standings-table td.sailor-col,
+  .standings-table th.boat-col,
+  .standings-table td.boat-col {
+    width: 175px;
+    min-width: 175px;
+    max-width: 175px;
+  }
+  .standings-table thead tr:nth-child(2) th {
+    position: sticky;
+    top: 0;
+    background: var(--bs-body-bg);
+    z-index: 2;
+  }
+  .standings-table thead tr:nth-child(3) th {
+    position: sticky;
+    top: 2.5rem;
+    background: var(--bs-body-bg);
+    z-index: 2;
+  }
+  .standings-table thead tr:nth-child(2) th:first-child,
+  .standings-table tbody td:first-child {
+    position: sticky;
+    left: 0;
+    background: var(--bs-body-bg);
+    z-index: 1;
+  }
+  .standings-table thead tr:nth-child(2) th:first-child {
+    z-index: 3;
+  }
 </style>
 
 <div class="table-responsive">
-  <table class="table table-striped table-sm">
+  <table class="table table-striped table-sm standings-table">
     <thead>
       <tr>
         <th colspan="6"></th>
@@ -48,8 +85,8 @@
       </tr>
       <tr>
         <th rowspan="2">Position</th>
-        <th rowspan="2">Sailor</th>
-        <th rowspan="2">Boat</th>
+        <th rowspan="2" class="sailor-col">Sailor</th>
+        <th rowspan="2" class="boat-col">Boat</th>
         <th rowspan="2">Sail No.</th>
         <th rowspan="2"># Races</th>
         <th rowspan="2" class="fw-bold">Total Points</th>
@@ -74,8 +111,8 @@
       {% for row in standings %}
       <tr>
         <td>{{ row.position }}</td>
-        <td>{{ row.sailor }}</td>
-        <td>{{ row.boat }}</td>
+        <td class="sailor-col">{{ row.sailor }}</td>
+        <td class="boat-col">{{ row.boat }}</td>
         <td>{{ row.sail_number }}</td>
         <td>{{ row.race_count }}</td>
         <td class="fw-bold">{{ '%.1f'|format(row.total_points) }}</td>


### PR DESCRIPTION
## Summary
- Set explicit widths for standings columns: Sailor and Boat at 175px, others at 65px
- Make Position column and table headers sticky to remain visible when scrolling

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a2448257308320b8c54cb53b9708df