### PR TITLE
Ensure traditional standings include non-finishers and center race headers

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -286,7 +286,7 @@ def _season_standings(season: int, scoring: str) -> tuple[list[dict], list[dict]
 
     standings: list[dict] = []
     for agg in aggregates.values():
-        if agg["race_count"] == 0:
+        if scoring == "league" and agg["race_count"] == 0:
             continue
         total = (
             agg["league_points"]

--- a/app/templates/standings.html
+++ b/app/templates/standings.html
@@ -36,6 +36,7 @@
     writing-mode: vertical-rl;
     transform: rotate(180deg);
     white-space: nowrap;
+    text-align: center;
   }
   .standings-table thead tr:nth-child(2) th:not(.series-group),
   .standings-table thead tr:nth-child(3) th,
@@ -63,6 +64,7 @@
     top: 2.5rem;
     background: var(--bs-body-bg);
     z-index: 2;
+    vertical-align: middle;
   }
   .standings-table thead tr:nth-child(2) th:first-child,
   .standings-table tbody td:first-child {
@@ -101,7 +103,7 @@
           {% set idx = loop.index0 %}
           {% set colour_class = colour_classes[idx % (colour_classes|length)] %}
           {% for race in group.races %}
-          <th class="series-{{ idx }} {{ colour_class }}{% if loop.index0 == 0 and idx > 0 %} series-boundary{% endif %} d-none rotate-90">{{ race.date }} {{ race.start_time[:5] if race.start_time }}</th>
+          <th class="series-{{ idx }} {{ colour_class }}{% if loop.index0 == 0 and idx > 0 %} series-boundary{% endif %} d-none rotate-90 text-center align-middle">{{ race.date }} {{ race.start_time[:5] if race.start_time }}</th>
           {% endfor %}
           <th class="{{ colour_class }}{% if idx > 0 %} series-boundary{% endif %}">Total</th>
         {% endfor %}

--- a/tests/test_standings.py
+++ b/tests/test_standings.py
@@ -1,0 +1,58 @@
+import json
+import shutil
+from pathlib import Path
+
+from app import routes
+
+
+def test_traditional_standings_include_non_finishers(tmp_path, monkeypatch):
+    # Copy settings required for scoring
+    shutil.copy(Path('data/settings.json'), tmp_path / 'settings.json')
+
+    # Minimal fleet with one finisher and one non-finisher
+    fleet = {
+        'competitors': [
+            {
+                'competitor_id': 'C1',
+                'sailor_name': 'Finisher',
+                'boat_name': 'Boat 1',
+                'sail_no': '1',
+                'starting_handicap_s_per_hr': 0,
+            },
+            {
+                'competitor_id': 'C2',
+                'sailor_name': 'NoFinish',
+                'boat_name': 'Boat 2',
+                'sail_no': '2',
+                'starting_handicap_s_per_hr': 0,
+            },
+        ]
+    }
+    (tmp_path / 'fleet.json').write_text(json.dumps(fleet))
+
+    # Series and race with a single DNF
+    series_dir = tmp_path / '2025' / 'Test'
+    (series_dir / 'races').mkdir(parents=True)
+    (series_dir / 'series_metadata.json').write_text(
+        json.dumps({'series_id': 'SER_2025_TEST', 'name': 'Test', 'season': 2025})
+    )
+    race = {
+        'race_id': 'RACE_2025-01-01_TEST_1',
+        'series_id': 'SER_2025_TEST',
+        'date': '2025-01-01',
+        'start_time': '10:00:00',
+        'entrants': [
+            {'competitor_id': 'C1', 'initial_handicap': 0, 'finish_time': '10:30:00'},
+            {'competitor_id': 'C2', 'initial_handicap': 0, 'status': 'DNF'},
+        ],
+    }
+    (series_dir / 'races' / 'RACE_2025-01-01_TEST_1.json').write_text(json.dumps(race))
+
+    monkeypatch.setattr(routes, 'DATA_DIR', tmp_path)
+
+    standings, _ = routes._season_standings(2025, 'traditional')
+    names = [row['sailor'] for row in standings]
+    assert 'NoFinish' in names
+    nonfin = next(row for row in standings if row['sailor'] == 'NoFinish')
+    assert nonfin['total_points'] == 2
+    assert nonfin['race_count'] == 0


### PR DESCRIPTION
## Summary
- Center race date/time headers when expanding individual race columns
- Include boats with no finishes in traditional standings and add regression test

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a2471a5ab4832080fd4f47bec704d5