### PR TITLE
Adjust traditional standings to drop worst scores

### DIFF
--- a/app/templates/standings.html
+++ b/app/templates/standings.html
@@ -123,7 +123,8 @@
           {% set colour_class = colour_classes[idx % (colour_classes|length)] %}
           {% for race in group.races %}
             {% set pts = row.race_points.get(race.race_id) %}
-            <td class="series-{{ idx }} d-none{% if loop.index0 == 0 and idx > 0 %} series-boundary{% endif %}">{% if pts is not none %}{{ '%.1f'|format(pts) }}{% else %}&nbsp;{% endif %}</td>
+            {% set dropped = scoring_format == 'traditional' and (row.dropped_races and race.race_id in row.dropped_races) %}
+            <td class="series-{{ idx }} d-none{% if loop.index0 == 0 and idx > 0 %} series-boundary{% endif %}{% if dropped %} text-muted{% endif %}">{% if pts is not none %}{{ '%.1f'|format(pts) }}{% else %}&nbsp;{% endif %}</td>
           {% endfor %}
           {% set total = row.series_totals.get(idx) %}
           <td class="{{ colour_class }}{% if idx > 0 %} series-boundary{% endif %}">{% if total is not none %}{{ '%.1f'|format(total) }}{% else %}&nbsp;{% endif %}</td>


### PR DESCRIPTION
## Summary
- drop the worst traditional race scores per series based on completed races
- grey out dropped race scores in the standings table
- test drop-score handling in traditional standings

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a2f2c70cc483209ed5512c428b40ad