### PR TITLE
Clarify traditional points series totals

### DIFF
--- a/app/templates/rules.html
+++ b/app/templates/rules.html
@@ -151,8 +151,13 @@
   </ul>
 
   <h3>Series/season result</h3>
-  <p>Sum your points across the races counted for that table. Lowest total wins
-     (tie-breaks as per Sailing Instructions/Race Committee guidance).</p>
+  <p>For each series, total your race points to get a series score. Because
+     different series may complete different numbers of races, each series
+     score is adjusted according to the number of races completed in that
+     series.</p>
+  <p>The season grand total is the sum of these adjusted series scores; the
+     lowest grand total wins (tie-breaks as per Sailing Instructions/Race
+     Committee guidance).</p>
 </section>
 
 {% endblock %}


### PR DESCRIPTION
## Summary
- explain that each series' low-points tally is adjusted by races completed and summed for the season grand total

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4690190148320ac7afba2754b5e46