### PR TITLE
Add Replit run configuration

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,1 @@
+run = "flask --app app run --host=0.0.0.0 --port=$PORT --debug"


### PR DESCRIPTION
## Summary
- add .replit file to run Flask app in Replit with `flask --app app run --host=0.0.0.0 --port=$PORT --debug`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae0b1db9088320b5fff5593ba2edc5