### PR TITLE
Fix Replit run command to use port 5000

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "flask --app app run --host=0.0.0.0 --port=5000 --debug"


### PR DESCRIPTION
## Summary
- specify Python runtime and pin Replit run command to port 5000

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae0b1db9088320b5fff5593ba2edc5