### PR TITLE
Fix .replit run command location

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,5 +1,5 @@
+run = "python -m flask --app app run --host=0.0.0.0 --port=5000 --debug"
+
 [[ports]]
 localPort = 5000   # the port your app listens on
 externalPort = 80  # the port the preview/domain uses
-
-run = "python -m flask --app app run --host=0.0.0.0 --port=5000 --debug"


### PR DESCRIPTION
## Summary
- move Flask `run` command to root-level in `.replit`

## Testing
- `python -m flask --app app run --host=0.0.0.0 --port=5000 --debug & sleep 2 && curl -I http://localhost:5000/ && kill %1`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af47850ca48320b4290c22f65a46cb