### PR TITLE
Handle errors during handicap recalculation on startup

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -7,7 +7,11 @@ def create_app():
     from . import routes
     app.register_blueprint(routes.bp)
 
-    routes.recalculate_handicaps()
+    app.logger.info("Starting handicap recalculation")
+    try:
+        routes.recalculate_handicaps()
+    except Exception:  # pylint: disable=broad-except
+        app.logger.exception("Error recalculating handicaps")
 
     return app
 


### PR DESCRIPTION
## Summary
- Wrap handicap recalculation in a try/except so the app continues to initialize
- Log the start of recalculation and any exceptions

## Testing
- `pip install -r requirements.txt`
- `pytest`
- `python - <<'PY'
import logging
logging.basicConfig(level=logging.INFO)
import app
PY`


------
https://chatgpt.com/codex/tasks/task_e_68af478f98548320a8e85a171657e38f