### PR TITLE
Add Python runtime declaration to Replit config

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,3 +1,4 @@
+language = "python"
 run = "python -m flask --app app run --host=0.0.0.0 --port=5000 --debug"
 
 [[ports]]


### PR DESCRIPTION
## Summary
- specify Python language in `.replit` so Replit provisions the proper runtime

## Testing
- `pytest`
- `python -m flask --app app run --host=0.0.0.0 --port=5000 --debug` (via timeout)


------
https://chatgpt.com/codex/tasks/task_e_68af4acb12b0832090eccd6bea496cc2