### PR TITLE
Use python3 in Replit run directive

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,5 +1,5 @@
 language = "python"
-run = "python -m flask --app app run --host=0.0.0.0 --port=5000 --debug"
+run = "python3 -m flask --app app run --host=0.0.0.0 --port=5000 --debug"
 
 [[ports]]
 localPort = 5000   # the port your app listens on


### PR DESCRIPTION
## Summary
- Ensure Replit uses `python3` when launching the Flask app.
- Confirmed interpreter availability with `which python && which python3`.

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af4bda7edc8320b451ddc6d594b97c